### PR TITLE
Add/default plan connection settings

### DIFF
--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -144,11 +144,11 @@ class Settings {
 				'description' => __( 'Set a default wourkout routine.', 'lsx-health-plan' ),
 				'id'          => 'connected_workouts',
 			),
-			'tip' => array(
+			/*'tip' => array(
 				'title'       => __( 'Tip', 'lsx-health-plan' ),
 				'description' => __( 'Set a default tip', 'lsx-health-plan' ),
 				'id'          => 'connected_tips',
-			),
+			),*/
 		);
 
 		foreach ( $default_types as $type => $default_type ) {

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -127,22 +127,27 @@ class Settings {
 				'title'       => __( 'Warm Up', 'lsx-health-plan' ),
 				'description' => __( 'Set a default warm up routine.', 'lsx-health-plan' ),
 				'limit'       => 1,
+				'id'          => 'plan_warmup',
 			),
 			'meal'    => array(
 				'title'       => __( 'Meal Plan', 'lsx-health-plan' ),
 				'description' => __( 'Set a default meal plan.', 'lsx-health-plan' ),
+				'id'          => 'connected_meals',
 			),
 			'recipe'  => array(
 				'title'       => __( 'Recipe', 'lsx-health-plan' ),
 				'description' => __( 'Set a default recipe.', 'lsx-health-plan' ),
+				'id'          => 'connected_recipes',
 			),
 			'workout' => array(
 				'title'       => __( 'Workout', 'lsx-health-plan' ),
 				'description' => __( 'Set a default wourkout routine.', 'lsx-health-plan' ),
+				'id'          => 'connected_workouts',
 			),
 			'tip' => array(
 				'title'       => __( 'Tip', 'lsx-health-plan' ),
 				'description' => __( 'Set a default tip', 'lsx-health-plan' ),
+				'id'          => 'connected_tips',
 			),
 		);
 
@@ -158,7 +163,7 @@ class Settings {
 				array(
 					'name'       => $default_type['title'],
 					'desc'       => $default_type['description'],
-					'id'         => 'default_' . $type,
+					'id'         => $default_type['id'],
 					'type'       => 'post_search_ajax',
 					'limit'      => $limit,
 					'sortable'   => $sortable,

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -114,6 +114,63 @@ class Settings {
 			'value'   => '',
 			'default' => __( "Let's get cooking! Delicious and easy to follow recipes.", 'lsx-health-plan' ),
 		) );
+
+		$cmb->add_field( array(
+			'id'      => 'global_defaults_title',
+			'type'    => 'title',
+			'name'    => __( 'Global Defaults', 'lsx-health-plan' ),
+			'default' => __( 'Global Defaults', 'lsx-health-plan' ),
+		) );
+
+		$default_types = array(
+			'page'    => array(
+				'title'       => __( 'Warm Up', 'lsx-health-plan' ),
+				'description' => __( 'Set a default warm up routine.', 'lsx-health-plan' ),
+				'limit'       => 1,
+			),
+			'meal'    => array(
+				'title'       => __( 'Meal Plan', 'lsx-health-plan' ),
+				'description' => __( 'Set a default meal plan.', 'lsx-health-plan' ),
+			),
+			'recipe'  => array(
+				'title'       => __( 'Recipe', 'lsx-health-plan' ),
+				'description' => __( 'Set a default recipe.', 'lsx-health-plan' ),
+			),
+			'workout' => array(
+				'title'       => __( 'Workout', 'lsx-health-plan' ),
+				'description' => __( 'Set a default wourkout routine.', 'lsx-health-plan' ),
+			),
+			'tip' => array(
+				'title'       => __( 'Tip', 'lsx-health-plan' ),
+				'description' => __( 'Set a default tip', 'lsx-health-plan' ),
+			),
+		);
+
+		foreach ( $default_types as $type => $default_type ) {
+			$limit    = 5;
+			$sortable = false;
+			if ( isset( $default_type['limit'] ) ) {
+				$limit    = $default_type['limit'];
+				$sortable = true;
+			}
+
+			$cmb->add_field(
+				array(
+					'name'       => $default_type['title'],
+					'desc'       => $default_type['description'],
+					'id'         => 'default_' . $type,
+					'type'       => 'post_search_ajax',
+					'limit'      => $limit,
+					'sortable'   => $sortable,
+					'query_args' => array(
+						'post_type'      => array( $type ),
+						'post_status'    => array( 'publish' ),
+						'posts_per_page' => -1,
+					),
+				)
+			);
+		}
+
 		$cmb->add_field( array(
 			'id'      => 'global_downloads_title',
 			'type'    => 'title',

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -24,6 +24,12 @@ function has_attached_post( $post_id = '', $meta_key = '', $single = true ) {
 	$items = get_post_meta( $post_id, $meta_key, $single );
 	if ( '' !== $items && false !== $items && 0 !== $items ) {
 		$has_post = true;
+	} else {
+		// Check for defaults.
+		$options = get_option( 'all' );
+		if ( isset( $options[ $meta_key ] ) && '' !== $options[ $meta_key ] && ! empty( $options[ $meta_key ] ) ) {
+			$has_post = true;
+		}
 	}
 	return $has_post;
 }

--- a/templates/tab-content-meal.php
+++ b/templates/tab-content-meal.php
@@ -24,7 +24,13 @@
 			<?php
 			$connected_meals = get_post_meta( get_the_ID(), 'connected_meals', true );
 			if ( empty( $connected_meals ) ) {
-				return;
+				$options = \lsx_health_plan\functions\get_option( 'all' );
+				if ( isset( $options['connected_meals'] ) && '' !== $options['connected_meals'] && ! empty( $options['connected_meals'] ) ) {
+					$connected_meals = $options['connected_meals'];
+					if ( ! array( $connected_meals ) ) {
+						$connected_meals = array( $connected_meals );
+					}
+				}
 			}
 			$args  = array(
 				'orderby'   => 'date',

--- a/templates/tab-content-recipes.php
+++ b/templates/tab-content-recipes.php
@@ -36,7 +36,13 @@
 			<?php
 			$connected_recipes = get_post_meta( get_the_ID(), 'connected_recipes', true );
 			if ( empty( $connected_recipes ) ) {
-				return;
+				$options = \lsx_health_plan\functions\get_option( 'all' );
+				if ( isset( $options['connected_recipes'] ) && '' !== $options['connected_recipes'] && ! empty( $options['connected_recipes'] ) ) {
+					$connected_recipes = $options['connected_recipes'];
+					if ( ! array( $connected_recipes ) ) {
+						$connected_recipes = array( $connected_recipes );
+					}
+				}
 			}
 			$args    = array(
 				'orderby'   => 'date',

--- a/templates/tab-content-warm-up.php
+++ b/templates/tab-content-warm-up.php
@@ -8,11 +8,17 @@
 
 <?php
 $warm_up = get_post_meta( get_the_ID(), 'plan_warmup', true );
-if ( false !== $warm_up && '' !== $warm_up ) {
+if ( false === $warm_up || '' === $warm_up ) {
+	$options = \lsx_health_plan\functions\get_option( 'all' );
+	if ( isset( $options['plan_warmup'] ) && '' !== $options['plan_warmup'] && ! empty( $options['plan_warmup'] ) ) {
+		$warm_up = $options['plan_warmup'];
+	}
+}
 
+if ( false !== $warm_up && '' !== $warm_up ) {
 	$warmup_query = new WP_Query(
 		array(
-			'post__in'  => $warm_up,
+			'post__in'  => array( $warm_up ),
 			'post_type' => 'page',
 		)
 	);

--- a/templates/tab-content-workout.php
+++ b/templates/tab-content-workout.php
@@ -59,7 +59,13 @@
 				<?php
 				$connected_workouts = get_post_meta( get_the_ID(), 'connected_workouts', true );
 				if ( empty( $connected_workouts ) ) {
-					return;
+					$options = \lsx_health_plan\functions\get_option( 'all' );
+					if ( isset( $options['connected_workouts'] ) && '' !== $options['connected_workouts'] && ! empty( $options['connected_workouts'] ) ) {
+						$connected_workouts = $options['connected_workouts'];
+						if ( ! array( $connected_workouts ) ) {
+							$connected_workouts = array( $connected_workouts );
+						}
+					}
 				}
 				$args     = array(
 					'orderby'   => 'date',


### PR DESCRIPTION
Description of the Change
 - Added in plugin settings to set default post type connections.

Benefits
 - Ability to set a default warm up, recipe, workout or meal for a day plan

Checklist:
 - [x] My code follows the code style of this project.
 - [x] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [x] All new and existing tests passed.

Applicable Issues
 - #24