### PR TITLE
Made sure that connected ids in the "trash" do not show. #20

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 ## Change log
 
+### 1.2.0 - (in development)
+* Patch - Made sure that connected ids in the "trash" do not show. #20
+
 ### 1.1.1 30 October 2019
 * Fix - Added in a function to filters downloads that do not exist.
 * Fix - Applied the_content filters to the meal plan paragraphs and the workouts text #18

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -23,7 +23,10 @@ function has_attached_post( $post_id = '', $meta_key = '', $single = true ) {
 	}
 	$items = get_post_meta( $post_id, $meta_key, $single );
 	if ( '' !== $items && false !== $items && 0 !== $items ) {
-		$has_post = true;
+		$items = check_posts_exist( $items );
+		if ( ! empty( $items ) ) {
+			$has_post = true;
+		}
 	} else {
 		// Check for defaults.
 		$options = get_option( 'all' );
@@ -153,6 +156,7 @@ function check_posts_exist( $post_ids = array() ) {
 			SELECT `ID` 
 			FROM `{$wpdb->posts}`
 			WHERE `ID` IN ({$post_ids})
+			AND `post_status` != 'trash'
 		";
 		$results = $wpdb->get_results( $query ); // WPCS: unprepared SQL
 		if ( ! empty( $results ) ) {


### PR DESCRIPTION
Description of the Change
 - Added in a clause to the `check_posts_exists` function to exclude `trash` post statuses.

Benefits
 - You will not see any empty tabs on the day plan

Checklist:
 - [x] My code follows the code style of this project.
 - [x] All new and existing tests passed.

Applicable Issues
 - #20