### PR TITLE
Add/35 - Settings to disable the post types

### DIFF
--- a/classes/class-core.php
+++ b/classes/class-core.php
@@ -112,6 +112,13 @@ class Core {
 	 * @return void
 	 */
 	public function get_post_types() {
-		return apply_filters( 'lsx_health_plan_post_types', $this->post_types );
+		$post_types = apply_filters( 'lsx_health_plan_post_types', $this->post_types );
+		foreach ( $post_types as $index => $post_type ) {
+			$is_disabled = \cmb2_get_option( 'lsx_health_plan_options', $post_type . '_disabled', false );
+			if ( true === $is_disabled || 1 === $is_disabled || 'on' === $is_disabled ) {
+				unset( $post_types[ $index ] );
+			}
+		}
+		return $post_types;
 	}
 }

--- a/classes/class-core.php
+++ b/classes/class-core.php
@@ -43,13 +43,6 @@ class Core {
 	public $scpo_engine;
 
 	/**
-	 * The post types available
-	 *
-	 * @var array
-	 */
-	public $post_types = array();
-
-	/**
 	 * Contructor
 	 */
 	public function __construct() {

--- a/classes/class-core.php
+++ b/classes/class-core.php
@@ -53,8 +53,8 @@ class Core {
 	 * Contructor
 	 */
 	public function __construct() {
-		$this->load_classes();
 		$this->load_includes();
+		$this->load_classes();
 	}
 
 	/**

--- a/classes/class-post-type.php
+++ b/classes/class-post-type.php
@@ -38,10 +38,15 @@ class Post_Type {
 	public function __construct() {
 		$this->enable_post_types();
 		add_filter( 'lsx_health_plan_post_types', array( $this, 'enable_post_types' ) );
-		foreach ( $this->post_types as $post_type ) {
-			require_once LSX_HEALTH_PLAN_PATH . 'classes/class-' . $post_type . '.php';
-			$classname        = ucwords( $post_type );
-			$this->$post_type = call_user_func_array( '\\lsx_health_plan\classes\\' . $classname . '::get_instance', array() );
+		foreach ( $this->post_types as $index => $post_type ) {
+			$is_disabled = \lsx_health_plan\functions\get_option( $post_type . '_disabled', false );
+			if ( true === $is_disabled || 1 === $is_disabled || 'on' === $is_disabled ) {
+				unset( $this->post_types[ $index ] );
+			} else {
+				require_once LSX_HEALTH_PLAN_PATH . 'classes/class-' . $post_type . '.php';
+				$classname        = ucwords( $post_type );
+				$this->$post_type = call_user_func_array( '\\lsx_health_plan\classes\\' . $classname . '::get_instance', array() );
+			}
 		}
 	}
 

--- a/classes/class-post-type.php
+++ b/classes/class-post-type.php
@@ -1,5 +1,6 @@
 <?php
 namespace lsx_health_plan\classes;
+use lsx_health_plan\functions;
 
 /**
  * LSX Health Plan Admin Class.

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -334,8 +334,8 @@ class Settings {
 		$cmb->add_field( array(
 			'id'      => 'post_type_toggles_title',
 			'type'    => 'title',
-			'name'    => __( 'Enable / Disable Post Types', 'lsx-health-plan' ),
-			'default' => __( 'Enable / Disable Post Types', 'lsx-health-plan' ),
+			'name'    => __( 'Disable Post Types', 'lsx-health-plan' ),
+			'default' => __( 'Disable Post Types', 'lsx-health-plan' ),
 			'description' => __( 'Disable post types if you are wanting a minimal site.', 'lsx-health-plan' ),
 		) );
 
@@ -345,10 +345,10 @@ class Settings {
 			}
 			$cmb->add_field( array(
 				'name'    => ucwords( $post_type ),
-				'id'      => $post_type . '_enabled',
+				'id'      => $post_type . '_disabled',
 				'type'    => 'checkbox',
 				'value'   => 1,
-				'default' => true,
+				'default' => 0,
 			) );
 		}
 	}

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -28,6 +28,11 @@ class Settings {
 	 */
 	public function __construct() {
 		add_action( 'cmb2_admin_init', array( $this, 'register_settings_page' ) );
+		add_action( 'lsx_hp_settings_page', array( $this, 'general_settings' ), 1, 1 );
+		add_action( 'lsx_hp_settings_page', array( $this, 'global_defaults' ), 3, 1 );
+		add_action( 'lsx_hp_settings_page', array( $this, 'global_downloads' ), 5, 1 );
+		add_action( 'lsx_hp_settings_page', array( $this, 'endpoint_translations' ), 7, 1 );
+		add_action( 'lsx_hp_settings_page', array( $this, 'post_type_toggles' ), 9, 1 );
 	}
 
 	/**
@@ -64,7 +69,16 @@ class Settings {
 			'parent_slug'  => 'options-general.php', // Make options page a submenu item of the themes menu.
 			'capability'   => 'manage_options', // Cap required to view options-page.
 		) );
+		do_action( 'lsx_hp_settings_page', $cmb );
+	}
 
+	/**
+	 * Registers the general settings.
+	 *
+	 * @param object $cmb new_cmb2_box().
+	 * @return void
+	 */
+	public function general_settings( $cmb ) {
 		$cmb->add_field( array(
 			'name'       => __( 'Membership Product', 'lsx-health-plan' ),
 			'id'         => 'membership_product',
@@ -114,7 +128,15 @@ class Settings {
 			'value'   => '',
 			'default' => __( "Let's get cooking! Delicious and easy to follow recipes.", 'lsx-health-plan' ),
 		) );
+	}
 
+	/**
+	 * Registers the global default settings.
+	 *
+	 * @param object $cmb new_cmb2_box().
+	 * @return void
+	 */
+	public function global_defaults( $cmb ) {
 		$cmb->add_field( array(
 			'id'      => 'global_defaults_title',
 			'type'    => 'title',
@@ -175,7 +197,15 @@ class Settings {
 				)
 			);
 		}
+	}
 
+	/**
+	 * Registers the global dowloads settings
+	 *
+	 * @param object $cmb new_cmb2_box().
+	 * @return void
+	 */
+	public function global_downloads( $cmb ) {
 		$cmb->add_field( array(
 			'id'      => 'global_downloads_title',
 			'type'    => 'title',
@@ -226,7 +256,15 @@ class Settings {
 				)
 			);
 		}
+	}
 
+	/**
+	 * Registers the endpoint translation settings.
+	 *
+	 * @param object $cmb new_cmb2_box().
+	 * @return void
+	 */
+	public function endpoint_translations( $cmb ) {
 		$cmb->add_field( array(
 			'id'      => 'endpoints_title',
 			'type'    => 'title',
@@ -284,4 +322,34 @@ class Settings {
 		) );
 	}
 
+	/**
+	 * Registers the post type toggle settings
+	 *
+	 * @param object $cmb new_cmb2_box().
+	 * @return void
+	 */
+	public function post_type_toggles( $cmb ) {
+		$post_types = apply_filters( 'lsx_health_plan_post_types', $this->post_types );
+
+		$cmb->add_field( array(
+			'id'      => 'post_type_toggles_title',
+			'type'    => 'title',
+			'name'    => __( 'Enable / Disable Post Types', 'lsx-health-plan' ),
+			'default' => __( 'Enable / Disable Post Types', 'lsx-health-plan' ),
+			'description' => __( 'Disable post types if you are wanting a minimal site.', 'lsx-health-plan' ),
+		) );
+
+		foreach ( $post_types as $post_type ) {
+			if ( 'plan' === $post_type ) {
+				continue;
+			}
+			$cmb->add_field( array(
+				'name'    => ucwords( $post_type ),
+				'id'      => $post_type . '_enabled',
+				'type'    => 'checkbox',
+				'value'   => 1,
+				'default' => true,
+			) );
+		}
+	}
 }

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -1,10 +1,14 @@
 <?php
+/**
+ * Contains the settings class for LSX
+ *
+ * @package lsx-health-plan
+ */
+
 namespace lsx_health_plan\classes;
 
 /**
- * Contains the tip post type
- *
- * @package lsx-health-plan
+ * Contains the settings for each post type \lsx_health_plan\classes\Settings().
  */
 class Settings {
 
@@ -19,9 +23,31 @@ class Settings {
 
 	/**
 	 * Option key, and option page slug
-		* @var string
-		*/
+	 *
+	 * @var string
+	 */
 	protected $screen_id = 'lsx_health_plan_settings';
+
+	/**
+	 * An array of the post types for the Global Downloads field.
+	 *
+	 * @var array
+	 */
+	public $download_types = array();
+
+	/**
+	 * An array of the post types for the Global Defaults field.
+	 *
+	 * @var array
+	 */
+	public $default_types = array();
+
+	/**
+	 * An array of the endpoints for the Endpoint Translation field.
+	 *
+	 * @var array
+	 */
+	public $endpoints = array();
 
 	/**
 	 * Contructor
@@ -51,24 +77,104 @@ class Settings {
 	}
 
 	/**
-	* Hook in and register a submenu options page for the Page post-type menu.
-	*/
+	 * Sets the variables needed for the fields.
+	 *
+	 * @return void
+	 */
+	public function set_vars() {
+		$this->default_types  = array(
+			'page' => array(
+				'title'       => __( 'Warm Up', 'lsx-health-plan' ),
+				'description' => __( 'Set a default warm up routine.', 'lsx-health-plan' ),
+				'limit'       => 1,
+				'id'          => 'plan_warmup',
+			),
+		);
+		$this->download_types = array(
+			'page' => array(
+				'title'       => __( 'Warm Up', 'lsx-health-plan' ),
+				'description' => __( 'Set a default warm up routine.', 'lsx-health-plan' ),
+				'limit'       => 1,
+			),
+		);
+		$this->endpoints      = array(
+			'endpoint_warm_up' => array(
+				'title'       => __( 'Warm Up Endpoint', 'lsx-health-plan' ),
+				'default'     => 'warm-up',
+			),
+		);
+
+		if ( post_type_exists( 'meal' ) ) {
+			$this->download_types['meal']     = array(
+				'title'       => __( 'Meal Plan', 'lsx-health-plan' ),
+				'description' => __( 'Set a default meal plan.', 'lsx-health-plan' ),
+			);
+			$this->default_types['meal']      = array(
+				'title'       => __( 'Meal Plan', 'lsx-health-plan' ),
+				'description' => __( 'Set a default meal plan.', 'lsx-health-plan' ),
+				'id'          => 'connected_meals',
+			);
+			$this->endpoints['endpoint_meal'] = array(
+				'title'   => __( 'Meal Endpoint', 'lsx-health-plan' ),
+				'default' => 'meal',
+			);
+		}
+		if ( post_type_exists( 'recipe' ) ) {
+			$this->download_types['recipe'] = array(
+				'title'       => __( 'Recipe', 'lsx-health-plan' ),
+				'description' => __( 'Set a default recipe.', 'lsx-health-plan' ),
+			);
+			$this->default_types['recipe'] = array(
+				'title'       => __( 'Recipe', 'lsx-health-plan' ),
+				'description' => __( 'Set a default recipe.', 'lsx-health-plan' ),
+				'id'          => 'connected_recipes',
+			);
+			$this->endpoints['endpoint_recipe'] = array(
+				'title'   => __( 'Recipes Endpoint', 'lsx-health-plan' ),
+				'default' => 'recipe',
+			);
+		}
+		if ( post_type_exists( 'workout' ) ) {
+			$this->download_types['workout'] = array(
+				'title'       => __( 'Workout', 'lsx-health-plan' ),
+				'description' => __( 'Set a default wourkout routine PDF.', 'lsx-health-plan' ),
+			);
+			$this->default_types['workout'] = array(
+				'title'       => __( 'Workout', 'lsx-health-plan' ),
+				'description' => __( 'Set a default wourkout routine.', 'lsx-health-plan' ),
+				'id'          => 'connected_workouts',
+			);
+			$this->endpoints['endpoint_workout'] = array(
+				'title'   => __( 'Workout Endpoint', 'lsx-health-plan' ),
+				'default' => 'workout',
+			);
+		}
+
+		$this->endpoints['login_slug'] = array(
+			'title'   => __( 'Login Slug', 'lsx-health-plan' ),
+			'default' => 'login',
+		);
+		$this->endpoints['my_plan_slug'] = array(
+			'title'   => __( 'My Plan Slug', 'lsx-health-plan' ),
+			'default' => 'my-plan',
+		);
+	}
+
+	/**
+	 * Hook in and register a submenu options page for the Page post-type menu.
+	 */
 	public function register_settings_page() {
-		/**
-		* Registers options page menu item and form.
-		*/
-		$cmb = new_cmb2_box( array(
-			'id'           => $this->screen_id,
-			'title'        => esc_html__( 'LSX Health Plan', 'cmb2' ),
-			'object_types' => array( 'options-page' ),
-			/*
-			* The following parameters are specific to the options-page box
-			* Several of these parameters are passed along to add_menu_page()/add_submenu_page().
-			*/
-			'option_key'   => 'lsx_health_plan_options', // The option key and admin menu page slug.
-			'parent_slug'  => 'options-general.php', // Make options page a submenu item of the themes menu.
-			'capability'   => 'manage_options', // Cap required to view options-page.
-		) );
+		$this->set_vars();
+		$cmb = new_cmb2_box(
+			array(
+				'id'           => $this->screen_id,
+				'title'        => esc_html__( 'LSX Health Plan', 'cmb2' ),
+				'object_types' => array( 'options-page' ),
+				'option_key'   => 'lsx_health_plan_options', // The option key and admin menu page slug.
+				'parent_slug'  => 'options-general.php', // Make options page a submenu item of the themes menu.
+				'capability'   => 'manage_options', // Cap required to view options-page.
+			)
+		);
 		do_action( 'lsx_hp_settings_page', $cmb );
 	}
 
@@ -79,55 +185,63 @@ class Settings {
 	 * @return void
 	 */
 	public function general_settings( $cmb ) {
-		$cmb->add_field( array(
-			'name'       => __( 'Membership Product', 'lsx-health-plan' ),
-			'id'         => 'membership_product',
-			'type'       => 'post_search_ajax',
-			// Optional :
-			'limit'      => 1,  // Limit selection to X items only (default 1)
-			'sortable'   => false, // Allow selected items to be sortable (default false)
-			'query_args' => array(
-				'post_type'      => array( 'product' ),
-				'post_status'    => array( 'publish' ),
-				'posts_per_page' => -1,
-			),
-		) );
+		$cmb->add_field(
+			array(
+				'name'       => __( 'Membership Product', 'lsx-health-plan' ),
+				'id'         => 'membership_product',
+				'type'       => 'post_search_ajax',
+				'limit'      => 1,
+				'sortable'   => false,
+				'query_args' => array(
+					'post_type'      => array( 'product' ),
+					'post_status'    => array( 'publish' ),
+					'posts_per_page' => -1,
+				),
+			)
+		);
 
-		$cmb->add_field( array(
-			'name'    => __( 'Your Warm-up Intro', 'lsx-health-plan' ),
-			'id'      => 'warmup_intro',
-			'type'    => 'textarea',
-			'value'   => '',
-			'default' => __( "Don't forget your warm-up! It's a vital part of your daily workout routine.", 'lsx-health-plan' ),
-		) );
-		$cmb->add_field( array(
-			'name'    => __( 'Your Workout Intro', 'lsx-health-plan' ),
-			'id'      => 'workout_intro',
-			'type'    => 'textarea',
-			'value'   => '',
-			'default' => __( "Let's do this! Smash your daily workout and reach your fitness goals.", 'lsx-health-plan' ),
-		) );
-		$cmb->add_field( array(
-			'name'    => __( 'Your Meal Plan Intro', 'lsx-health-plan' ),
-			'id'      => 'meal_plan_intro',
-			'type'    => 'textarea',
-			'value'   => '',
-			'default' => __( 'Get the right mix of nutrients to keep muscles strong & healthy.', 'lsx-health-plan' ),
-		) );
-		$cmb->add_field( array(
-			'name'    => __( 'Recipes Intro', 'lsx-health-plan' ),
-			'id'      => 'recipes_intro',
-			'type'    => 'textarea',
-			'value'   => '',
-			'default' => __( "Let's get cooking! Delicious and easy to follow recipes.", 'lsx-health-plan' ),
-		) );
-		$cmb->add_field( array(
-			'name'    => __( 'Recipes Intro', 'lsx-health-plan' ),
-			'id'      => 'recipes_intro',
-			'type'    => 'textarea',
-			'value'   => '',
-			'default' => __( "Let's get cooking! Delicious and easy to follow recipes.", 'lsx-health-plan' ),
-		) );
+		$cmb->add_field(
+			array(
+				'name'    => __( 'Your Warm-up Intro', 'lsx-health-plan' ),
+				'id'      => 'warmup_intro',
+				'type'    => 'textarea',
+				'value'   => '',
+				'default' => __( "Don't forget your warm-up! It's a vital part of your daily workout routine.", 'lsx-health-plan' ),
+			)
+		);
+		if ( post_type_exists( 'workout' ) ) {
+			$cmb->add_field(
+				array(
+					'name'    => __( 'Your Workout Intro', 'lsx-health-plan' ),
+					'id'      => 'workout_intro',
+					'type'    => 'textarea',
+					'value'   => '',
+					'default' => __( "Let's do this! Smash your daily workout and reach your fitness goals.", 'lsx-health-plan' ),
+				)
+			);
+		}
+		if ( post_type_exists( 'meal' ) ) {
+			$cmb->add_field(
+				array(
+					'name'    => __( 'Your Meal Plan Intro', 'lsx-health-plan' ),
+					'id'      => 'meal_plan_intro',
+					'type'    => 'textarea',
+					'value'   => '',
+					'default' => __( 'Get the right mix of nutrients to keep muscles strong & healthy.', 'lsx-health-plan' ),
+				)
+			);
+		}
+		if ( post_type_exists( 'recipe' ) ) {
+			$cmb->add_field(
+				array(
+					'name'    => __( 'Recipes Intro', 'lsx-health-plan' ),
+					'id'      => 'recipes_intro',
+					'type'    => 'textarea',
+					'value'   => '',
+					'default' => __( "Let's get cooking! Delicious and easy to follow recipes.", 'lsx-health-plan' ),
+				)
+			);
+		}
 	}
 
 	/**
@@ -137,43 +251,16 @@ class Settings {
 	 * @return void
 	 */
 	public function global_defaults( $cmb ) {
-		$cmb->add_field( array(
-			'id'      => 'global_defaults_title',
-			'type'    => 'title',
-			'name'    => __( 'Global Defaults', 'lsx-health-plan' ),
-			'default' => __( 'Global Defaults', 'lsx-health-plan' ),
-		) );
-
-		$default_types = array(
-			'page'    => array(
-				'title'       => __( 'Warm Up', 'lsx-health-plan' ),
-				'description' => __( 'Set a default warm up routine.', 'lsx-health-plan' ),
-				'limit'       => 1,
-				'id'          => 'plan_warmup',
-			),
-			'meal'    => array(
-				'title'       => __( 'Meal Plan', 'lsx-health-plan' ),
-				'description' => __( 'Set a default meal plan.', 'lsx-health-plan' ),
-				'id'          => 'connected_meals',
-			),
-			'recipe'  => array(
-				'title'       => __( 'Recipe', 'lsx-health-plan' ),
-				'description' => __( 'Set a default recipe.', 'lsx-health-plan' ),
-				'id'          => 'connected_recipes',
-			),
-			'workout' => array(
-				'title'       => __( 'Workout', 'lsx-health-plan' ),
-				'description' => __( 'Set a default wourkout routine.', 'lsx-health-plan' ),
-				'id'          => 'connected_workouts',
-			),
-			/*'tip' => array(
-				'title'       => __( 'Tip', 'lsx-health-plan' ),
-				'description' => __( 'Set a default tip', 'lsx-health-plan' ),
-				'id'          => 'connected_tips',
-			),*/
+		$cmb->add_field(
+			array(
+				'id'      => 'global_defaults_title',
+				'type'    => 'title',
+				'name'    => __( 'Global Defaults', 'lsx-health-plan' ),
+				'default' => __( 'Global Defaults', 'lsx-health-plan' ),
+			)
 		);
 
-		foreach ( $default_types as $type => $default_type ) {
+		foreach ( $this->default_types as $type => $default_type ) {
 			$limit    = 5;
 			$sortable = false;
 			if ( isset( $default_type['limit'] ) ) {
@@ -206,34 +293,16 @@ class Settings {
 	 * @return void
 	 */
 	public function global_downloads( $cmb ) {
-		$cmb->add_field( array(
-			'id'      => 'global_downloads_title',
-			'type'    => 'title',
-			'name'    => __( 'Global Downloads', 'lsx-health-plan' ),
-			'default' => __( 'Global Downloads', 'lsx-health-plan' ),
-		) );
-
-		$download_types = array(
-			'page'    => array(
-				'title'       => __( 'Warm Up', 'lsx-health-plan' ),
-				'description' => __( 'Set a default warm up routine.', 'lsx-health-plan' ),
-				'limit'       => 1,
-			),
-			'meal'    => array(
-				'title'       => __( 'Meal Plan', 'lsx-health-plan' ),
-				'description' => __( 'Set a default meal plan.', 'lsx-health-plan' ),
-			),
-			'recipe'  => array(
-				'title'       => __( 'Recipe', 'lsx-health-plan' ),
-				'description' => __( 'Set a default recipe.', 'lsx-health-plan' ),
-			),
-			'workout' => array(
-				'title'       => __( 'Workout', 'lsx-health-plan' ),
-				'description' => __( 'Set a default wourkout routine PDF.', 'lsx-health-plan' ),
-			),
+		$cmb->add_field(
+			array(
+				'id'      => 'global_downloads_title',
+				'type'    => 'title',
+				'name'    => __( 'Global Downloads', 'lsx-health-plan' ),
+				'default' => __( 'Global Downloads', 'lsx-health-plan' ),
+			)
 		);
 
-		foreach ( $download_types as $type => $download_type ) {
+		foreach ( $this->download_types as $type => $download_type ) {
 			$limit    = 5;
 			$sortable = false;
 			if ( isset( $download_type['limit'] ) ) {
@@ -265,61 +334,26 @@ class Settings {
 	 * @return void
 	 */
 	public function endpoint_translations( $cmb ) {
-		$cmb->add_field( array(
-			'id'      => 'endpoints_title',
-			'type'    => 'title',
-			'name'    => __( 'Set Endpoint Translations', 'lsx-health-plan' ),
-			'default' => __( 'Set Endpoint Translations', 'lsx-health-plan' ),
-			'description' => __( 'You need to resave your permalinks after changing the endpoint settings.', 'lsx-health-plan' ),
-		) );
-
-		$cmb->add_field( array(
-			'name'    => __( 'Warm Up Endpoint', 'lsx-health-plan' ),
-			'id'      => 'endpoint_warm_up',
-			'type'    => 'input',
-			'value'   => '',
-			'default' => 'warm-up',
-		) );
-
-		$cmb->add_field( array(
-			'name'    => __( 'Workout Endpoint', 'lsx-health-plan' ),
-			'id'      => 'endpoint_workout',
-			'type'    => 'input',
-			'value'   => '',
-			'default' => 'workout',
-		) );
-
-		$cmb->add_field( array(
-			'name'    => __( 'Meal Endpoint', 'lsx-health-plan' ),
-			'id'      => 'endpoint_meal',
-			'type'    => 'input',
-			'value'   => '',
-			'default' => 'meal',
-		) );
-
-		$cmb->add_field( array(
-			'name'    => __( 'Recipes Endpoint', 'lsx-health-plan' ),
-			'id'      => 'endpoint_recipe',
-			'type'    => 'input',
-			'value'   => '',
-			'default' => 'recipe',
-		) );
-
-		$cmb->add_field( array(
-			'name'    => __( 'Login Slug', 'lsx-health-plan' ),
-			'id'      => 'login_slug',
-			'type'    => 'input',
-			'value'   => '',
-			'default' => 'login',
-		) );
-
-		$cmb->add_field( array(
-			'name'    => __( 'My Plan Slug', 'lsx-health-plan' ),
-			'id'      => 'my_plan_slug',
-			'type'    => 'input',
-			'value'   => '',
-			'default' => 'my-plan',
-		) );
+		$cmb->add_field(
+			array(
+				'id'          => 'endpoints_title',
+				'type'        => 'title',
+				'name'        => __( 'Set Endpoint Translations', 'lsx-health-plan' ),
+				'default'     => __( 'Set Endpoint Translations', 'lsx-health-plan' ),
+				'description' => __( 'You need to resave your permalinks after changing the endpoint settings.', 'lsx-health-plan' ),
+			)
+		);
+		foreach ( $this->endpoints as $slug => $endpoint_vars ) {
+			$cmb->add_field(
+				array(
+					'name'    => $endpoint_vars['title'],
+					'id'      => $slug,
+					'type'    => 'input',
+					'value'   => '',
+					'default' => $endpoint_vars['default'],
+				)
+			);
+		}
 	}
 
 	/**
@@ -331,25 +365,29 @@ class Settings {
 	public function post_type_toggles( $cmb ) {
 		$post_types = apply_filters( 'lsx_health_plan_post_types', $this->post_types );
 
-		$cmb->add_field( array(
-			'id'      => 'post_type_toggles_title',
-			'type'    => 'title',
-			'name'    => __( 'Disable Post Types', 'lsx-health-plan' ),
-			'default' => __( 'Disable Post Types', 'lsx-health-plan' ),
-			'description' => __( 'Disable post types if you are wanting a minimal site.', 'lsx-health-plan' ),
-		) );
+		$cmb->add_field(
+			array(
+				'id'          => 'post_type_toggles_title',
+				'type'        => 'title',
+				'name'        => __( 'Disable Post Types', 'lsx-health-plan' ),
+				'default'     => __( 'Disable Post Types', 'lsx-health-plan' ),
+				'description' => __( 'Disable post types if you are wanting a minimal site.', 'lsx-health-plan' ),
+			)
+		);
 
 		foreach ( $post_types as $post_type ) {
 			if ( 'plan' === $post_type ) {
 				continue;
 			}
-			$cmb->add_field( array(
-				'name'    => ucwords( $post_type ),
-				'id'      => $post_type . '_disabled',
-				'type'    => 'checkbox',
-				'value'   => 1,
-				'default' => 0,
-			) );
+			$cmb->add_field(
+				array(
+					'name'    => ucwords( $post_type ),
+					'id'      => $post_type . '_disabled',
+					'type'    => 'checkbox',
+					'value'   => 1,
+					'default' => 0,
+				)
+			);
 		}
 	}
 }

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -76,9 +76,16 @@ class Setup {
 		add_shortcode( 'lsx_health_plan_my_profile_tabs', '\lsx_health_plan\shortcodes\my_profile_tabs' );
 		add_shortcode( 'lsx_health_plan_my_profile_block', '\lsx_health_plan\shortcodes\my_profile_box' );
 		add_shortcode( 'lsx_health_plan_day_plan_block', '\lsx_health_plan\shortcodes\day_plan_box' );
-		add_shortcode( 'lsx_health_plan_featured_video_block', '\lsx_health_plan\shortcodes\feature_video_box' );
-		add_shortcode( 'lsx_health_plan_featured_recipes_block', '\lsx_health_plan\shortcodes\feature_recipes_box' );
-		add_shortcode( 'lsx_health_plan_featured_tips_block', '\lsx_health_plan\shortcodes\feature_tips_box' );
 		add_shortcode( 'lsx_health_plan_account_notices', '\lsx_health_plan\shortcodes\account_notices' );
+
+		if ( post_type_exists( 'video' ) ) {
+			add_shortcode( 'lsx_health_plan_featured_video_block', '\lsx_health_plan\shortcodes\feature_video_box' );
+		}
+		if ( post_type_exists( 'recipe' ) ) {
+			add_shortcode( 'lsx_health_plan_featured_recipes_block', '\lsx_health_plan\shortcodes\feature_recipes_box' );
+		}
+		if ( post_type_exists( 'tip' ) ) {
+			add_shortcode( 'lsx_health_plan_featured_tips_block', '\lsx_health_plan\shortcodes\feature_tips_box' );
+		}
 	}
 }

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -27,7 +27,7 @@ class Setup {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
-		add_action( 'init', array( $this, 'load_shortcodes' ) );
+		add_action( 'wp_head', array( $this, 'load_shortcodes' ) );
 		$this->load_classes();
 	}
 

--- a/classes/class-woocommerce.php
+++ b/classes/class-woocommerce.php
@@ -26,6 +26,9 @@ class Woocommerce {
 		add_filter( 'woocommerce_order_button_text', array( $this, 'checkout_button_text' ), 10, 1 );
 		add_filter( 'woocommerce_get_breadcrumb', array( $this, 'breadcrumbs' ), 30, 1 );
 
+		// Checkout.
+		add_action( 'woocommerce_checkout_after_order_review', array( $this, 'payment_gateway_logos' ) );
+
 		// Redirect to the Edit Account Template.
 		add_filter( 'template_include', array( $this, 'account_endpoint_redirect' ), 99 );
 
@@ -638,6 +641,24 @@ class Woocommerce {
 	public function lost_password_page_title() {
 		?>
 		<h1 class="lost-your-password-title"><?php esc_html_e( 'Lost your password?', 'lsx-health-plan' ); ?></h1>
+		<?php
+	}
+
+	/**
+	 * Add Lets Enrypt and PayFast logos to cart.
+	**/
+	public function payment_gateway_logos() {
+		$encript_image = LSX_HEALTH_PLAN_URL . 'assets/images/le-logo.svg';
+		$payfast_image   = LSX_HEALTH_PLAN_URL . 'assets/images/secure-payments.png';
+		?>
+		<div class="row text-center vertical-align">
+			<div class="col-md-6 col-sm-6 col-xs-6">
+				<img src="<?php echo esc_url( $encript_image ); ?>" alt="lets_encrypt"/>
+			</div>
+			<div class="col-md-6 col-sm-6 col-xs-6">
+				<img src="<?php echo esc_url( $payfast_image ); ?>" alt="payfast"/>
+			</div>
+		</div>
 		<?php
 	}
 }

--- a/includes/conditionals.php
+++ b/includes/conditionals.php
@@ -25,7 +25,7 @@ function lsx_health_plan_has_warmup( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_workout( $post_id = '' ) {
-	if ( ! post_exists( 'workout' ) ) {
+	if ( ! post_type_exists( 'workout' ) ) {
 		return false;
 	}
 	if ( '' === $post_id ) {
@@ -41,7 +41,7 @@ function lsx_health_plan_has_workout( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_meal( $post_id = '' ) {
-	if ( ! post_exists( 'meal' ) ) {
+	if ( ! post_type_exists( 'meal' ) ) {
 		return false;
 	}
 	if ( '' === $post_id ) {
@@ -57,7 +57,7 @@ function lsx_health_plan_has_meal( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_recipe( $post_id = '' ) {
-	if ( ! post_exists( 'recipe' ) ) {
+	if ( ! post_type_exists( 'recipe' ) ) {
 		return false;
 	}
 	if ( '' === $post_id ) {
@@ -91,7 +91,7 @@ function lsx_health_plan_has_downloads( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_tip( $post_id = '' ) {
-	if ( ! post_exists( 'tip' ) ) {
+	if ( ! post_type_exists( 'tip' ) ) {
 		return false;
 	}
 	if ( '' === $post_id ) {
@@ -107,7 +107,7 @@ function lsx_health_plan_has_tip( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_video( $post_id = '' ) {
-	if ( ! post_exists( 'video' ) ) {
+	if ( ! post_type_exists( 'video' ) ) {
 		return false;
 	}
 	if ( '' === $post_id ) {

--- a/includes/conditionals.php
+++ b/includes/conditionals.php
@@ -25,6 +25,9 @@ function lsx_health_plan_has_warmup( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_workout( $post_id = '' ) {
+	if ( ! post_exists( 'workout' ) ) {
+		return false;
+	}
 	if ( '' === $post_id ) {
 		$post_id = get_the_ID();
 	}
@@ -38,6 +41,9 @@ function lsx_health_plan_has_workout( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_meal( $post_id = '' ) {
+	if ( ! post_exists( 'meal' ) ) {
+		return false;
+	}
 	if ( '' === $post_id ) {
 		$post_id = get_the_ID();
 	}
@@ -51,6 +57,9 @@ function lsx_health_plan_has_meal( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_recipe( $post_id = '' ) {
+	if ( ! post_exists( 'recipe' ) ) {
+		return false;
+	}
 	if ( '' === $post_id ) {
 		$post_id = get_the_ID();
 	}
@@ -82,6 +91,9 @@ function lsx_health_plan_has_downloads( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_tip( $post_id = '' ) {
+	if ( ! post_exists( 'tip' ) ) {
+		return false;
+	}
 	if ( '' === $post_id ) {
 		$post_id = get_the_ID();
 	}
@@ -95,6 +107,9 @@ function lsx_health_plan_has_tip( $post_id = '' ) {
  * @return boolean
  */
 function lsx_health_plan_has_video( $post_id = '' ) {
+	if ( ! post_exists( 'video' ) ) {
+		return false;
+	}
 	if ( '' === $post_id ) {
 		$post_id = get_the_ID();
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -67,13 +67,8 @@ function get_option( $key = '', $default = false ) {
  * @return mixed           Option value
  */
 function get_downloads( $type = 'all', $post_id = '' ) {
-	$post_types = array(
-		'page',
-		'meal',
-		'workout',
-		'recipe',
-		'video',
-	);
+	$lsx_health_plan = \lsx_health_plan();
+	$post_types      = $lsx_health_plan->get_post_types();
 	if ( '' === $post_id ) {
 		$post_id = get_the_ID();
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -60,25 +60,6 @@ function get_option( $key = '', $default = false ) {
 }
 
 /**
- * Add Lets Enrypt and PayFast logos to cart
- **/
-
-add_action( 'woocommerce_checkout_after_order_review', function() {
-	$encript_image = LSX_HEALTH_PLAN_URL . 'assets/images/le-logo.svg';
-	$payfast_image   = LSX_HEALTH_PLAN_URL . 'assets/images/secure-payments.png';
-	?>
-	<div class="row text-center vertical-align">
-		<div class="col-md-6 col-sm-6 col-xs-6">
-			<img src="<?php echo esc_url( $encript_image ); ?>" alt="lets_encrypt"/>
-		</div>
-		<div class="col-md-6 col-sm-6 col-xs-6">
-			<img src="<?php echo esc_url( $payfast_image ); ?>" alt="payfast"/>
-		</div>
-	</div>
-	<?php
-});
-
-/**
  * Returns the downloads attached to the items
  * @since  0.1.0
  * @param  string $key     Options array key

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -42,6 +42,9 @@ function lsx_health_plan_warmup_box() {
 * @return void
 */
 function lsx_health_plan_workout_box() {
+	if ( ! post_type_exists( 'workout' ) ) {
+		return;
+	}
 	?>
 	<div class="col-md-4" >
 		<div class="lsx-health-plan-box">
@@ -73,6 +76,9 @@ function lsx_health_plan_workout_box() {
 * @return void
 */
 function lsx_health_plan_meal_box() {
+	if ( ! post_type_exists( 'meal' ) ) {
+		return;
+	}
 	?>
 	<div class="col-md-4" >
 		<div class="lsx-health-plan-box">
@@ -104,6 +110,9 @@ function lsx_health_plan_meal_box() {
 * @return void
 */
 function lsx_health_plan_recipe_box() {
+	if ( ! post_type_exists( 'recipe' ) ) {
+		return;
+	}
 	?>
 	<div class="col-md-4" >
 		<div class="lsx-health-plan-box">
@@ -470,6 +479,9 @@ function lsx_health_plan_week_plan_block() {
  * @return void
  */
 function lsx_health_plan_featured_video_block() {
+	if ( ! post_type_exists( 'video' ) ) {
+		return;
+	}
 	include LSX_HEALTH_PLAN_PATH . '/templates/featured-videos.php';
 }
 
@@ -479,6 +491,9 @@ function lsx_health_plan_featured_video_block() {
  * @return void
  */
 function lsx_health_plan_featured_recipes_block() {
+	if ( ! post_type_exists( 'recipe' ) ) {
+		return;
+	}
 	include LSX_HEALTH_PLAN_PATH . '/templates/featured-recipes.php';
 }
 
@@ -488,6 +503,9 @@ function lsx_health_plan_featured_recipes_block() {
  * @return void
  */
 function lsx_health_plan_featured_tips_block() {
+	if ( ! post_type_exists( 'tip' ) ) {
+		return;
+	}
 	include LSX_HEALTH_PLAN_PATH . '/templates/featured-tips.php';
 }
 

--- a/templates/tab-content-meal.php
+++ b/templates/tab-content-meal.php
@@ -104,7 +104,7 @@
 					<div class="row tip-row extras-box">
 						<?php
 						$connected_recipes = get_post_meta( get_the_ID(), 'connected_recipes', true );
-						if ( ! empty( $connected_recipes ) ) {
+						if ( ! empty( $connected_recipes ) && post_type_exists( 'recipe' ) ) {
 							?>
 							<div class="col-md-4">
 								<div class="content-box tip-left box-shadow">
@@ -126,11 +126,13 @@
 							</div>
 						<?php } ?>
 						
-						<div class="col-md-4">
-							<div class="tip-right">
-								<?php echo do_shortcode( '[lsx_health_plan_featured_tips_block]' ); ?>
+						<?php if ( post_type_exists( 'tip' ) ) { ?>
+							<div class="col-md-4">
+								<div class="tip-right">
+									<?php echo do_shortcode( '[lsx_health_plan_featured_tips_block]' ); ?>
+								</div>
 							</div>
-						</div>
+						<?php } ?>
 					</div>
 			</div>
 		</div>

--- a/templates/tab-content-workout.php
+++ b/templates/tab-content-workout.php
@@ -112,7 +112,9 @@
 												<tr>
 													<th><?php esc_html_e( 'Workout', 'lsx-health-plan' ); ?></th> 
 													<th class="center-mobile"><?php esc_html_e( 'Reps / Time / Distance', 'lsx-health-plan' ); ?></th>
-													<th class="center-mobile"><?php esc_html_e( 'Video', 'lsx-health-plan' ); ?></th>
+													<?php if ( post_type_exists( 'video' ) ) { ?>
+														<th class="center-mobile"><?php esc_html_e( 'Video', 'lsx-health-plan' ); ?></th>
+													<?php } ?>
 												</tr>
 												<?php
 												foreach ( $groups as $group ) {
@@ -128,9 +130,11 @@
 													<tr>
 														<td class="workout-title-item"><?php echo esc_html( $workout_name ); ?></td>
 														<td class="reps-field-item center-mobile"><?php echo esc_html( $workout_reps ); ?></td>
-														<td class="video-button-item center-mobile">
-															<?php lsx_health_plan_workout_video_play_button( $m, $group ); ?>
-														</td>
+														<?php if ( post_type_exists( 'video' ) ) { ?>
+															<td class="video-button-item center-mobile">
+																<?php lsx_health_plan_workout_video_play_button( $m, $group ); ?>
+															</td>
+														<?php } ?>
 													</tr>
 													<?php
 													$m++;


### PR DESCRIPTION
@viscosho I have added in settings to allow you to disable certain post types if you want.   I have also refactored the `class-settings.php` file to be more modular,  so that when you disable a post type, it removes everything relating to that.

This is what the settings look like
![Screenshot 2020-01-15 at 13 36 28](https://user-images.githubusercontent.com/1805603/72430910-2c8bb280-379c-11ea-9c22-b0dd120bd0a5.png)

**How to test**
1. Switch to the `add/35` branch.
2. Disable `videos` first,  then view `Day 1`  and open all the links.  Are the video sections and widgets missing.
3. View the account page,  is anything relating to the videos there showing?

Once you have checked that, disable the next post type, and repeat.

NB:  if you disable a post type,  you will need to re save the permalinks.   If you disable `workout` and dont re save the permalink, then the endpoint will still be active,  it will just 404.
