### PR TITLE
Changing all the kg's and cm's in the detail boxes to just kg and cm

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 ## Change log
 
+### 1.3.0 (In development)
+* Fix - Changing all the kg's and cm's in the detail boxes to just kg and cm (no plural).
+
 ### 1.2.0 - 19 December 2019
 * Dev - Added in translatable endpoint settings.
 * Dev - Added in placeholder image for Tips.

--- a/classes/class-woocommerce.php
+++ b/classes/class-woocommerce.php
@@ -511,8 +511,8 @@ class Woocommerce {
 		return apply_filters( 'iconic_account_fields', array(
 			'weight_start'  => array(
 				'type'                 => 'text',
-				'label'                => __( 'Weight', 'lsx-health-plan' ),
-				'placeholder'          => __( 'kg’s', 'lsx-health-plan' ),
+				'label'                => __( 'Weight:', 'lsx-health-plan' ),
+				'placeholder'          => __( 'kg', 'lsx-health-plan' ),
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,
 				'hide_in_checkout'     => false,
@@ -521,8 +521,8 @@ class Woocommerce {
 			),
 			'weight_goal'   => array(
 				'type'                 => 'text',
-				'label'                => __( 'Weight', 'lsx-health-plan' ),
-				'placeholder'          => __( 'kg’s', 'lsx-health-plan' ),
+				'label'                => __( 'Weight:', 'lsx-health-plan' ),
+				'placeholder'          => __( 'kg', 'lsx-health-plan' ),
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,
 				'hide_in_checkout'     => false,
@@ -531,8 +531,8 @@ class Woocommerce {
 			),
 			'weight_end'    => array(
 				'type'                 => 'text',
-				'label'                => __( 'Weight', 'lsx-health-plan' ),
-				'placeholder'          => __( 'kg’s', 'lsx-health-plan' ),
+				'label'                => __( 'Weight:', 'lsx-health-plan' ),
+				'placeholder'          => __( 'kg', 'lsx-health-plan' ),
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,
 				'hide_in_checkout'     => false,
@@ -541,8 +541,8 @@ class Woocommerce {
 			),
 			'waist_start'   => array(
 				'type'                 => 'text',
-				'label'                => __( 'Waist', 'lsx-health-plan' ),
-				'placeholder'          => __( 'cm’s', 'lsx-health-plan' ),
+				'label'                => __( 'Waist:', 'lsx-health-plan' ),
+				'placeholder'          => __( 'cm', 'lsx-health-plan' ),
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,
 				'hide_in_checkout'     => false,
@@ -551,8 +551,8 @@ class Woocommerce {
 			),
 			'waist_goal'    => array(
 				'type'                 => 'text',
-				'label'                => __( 'Waist', 'lsx-health-plan' ),
-				'placeholder'          => __( 'cm’s', 'lsx-health-plan' ),
+				'label'                => __( 'Waist:', 'lsx-health-plan' ),
+				'placeholder'          => __( 'cm', 'lsx-health-plan' ),
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,
 				'hide_in_checkout'     => false,
@@ -561,8 +561,8 @@ class Woocommerce {
 			),
 			'waist_end'     => array(
 				'type'                 => 'text',
-				'label'                => __( 'Waist', 'lsx-health-plan' ),
-				'placeholder'          => __( 'cm’s', 'lsx-health-plan' ),
+				'label'                => __( 'Waist:', 'lsx-health-plan' ),
+				'placeholder'          => __( 'cm', 'lsx-health-plan' ),
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,
 				'hide_in_checkout'     => false,
@@ -571,7 +571,7 @@ class Woocommerce {
 			),
 			'fitness_start' => array(
 				'type'                 => 'text',
-				'label'                => __( 'Fitness Test Score', 'lsx-health-plan' ),
+				'label'                => __( 'Fitness Test Score:', 'lsx-health-plan' ),
 				'placeholder'          => '#',
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,
@@ -581,7 +581,7 @@ class Woocommerce {
 			),
 			'fitness_goal'  => array(
 				'type'                 => 'text',
-				'label'                => __( 'Fitness Test Score', 'lsx-health-plan' ),
+				'label'                => __( 'Fitness Test Score:', 'lsx-health-plan' ),
 				'placeholder'          => '#',
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,
@@ -591,7 +591,7 @@ class Woocommerce {
 			),
 			'fitness_end'   => array(
 				'type'                 => 'text',
-				'label'                => __( 'Fitness Test Score', 'lsx-health-plan' ),
+				'label'                => __( 'Fitness Test Score:', 'lsx-health-plan' ),
 				'placeholder'          => '#',
 				'hide_in_account'      => false,
 				'hide_in_admin'        => false,


### PR DESCRIPTION
Changing all the kg's and cm's in the detail boxes to just kg and cm (no plural).

This is to fix these 2 issues:
- https://github.com/lightspeeddevelopment/lsx-health-plan/issues/37
- https://github.com/lightspeeddevelopment/lsx-health-plan/issues/38