### PR TITLE
Fixed the integration with CMB2, and detecting when it is active. #59

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Dev - Added a `show_downloads` parameter to the weekly plan shortcode, which displays a list of the downloads added to the downloads category.
 * Dev - Refactored single plan tabs and the tab output, so they are passed through filters.
 * Dev - Design Updates to Recipes Cards.
+* Fix - Fixed the integration with CMB2, and detecting when it is active.
 
 ### 1.2.0 - 19 December 2019
 * Dev - Added in translatable endpoint settings.

--- a/classes/class-integrations.php
+++ b/classes/class-integrations.php
@@ -94,10 +94,8 @@ class Integrations {
 	 * @return void
 	 */
 	public function cmb2_post_search_ajax() {
-		if ( class_exists( 'CMB2_Bootstrap_260' ) ) {
-			require_once LSX_HEALTH_PLAN_PATH . 'vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php';
-			$this->cmb2_post_search_ajax = new \MAG_CMB2_Field_Post_Search_Ajax();
-		}
+		require_once LSX_HEALTH_PLAN_PATH . 'vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php';
+		$this->cmb2_post_search_ajax = new \MAG_CMB2_Field_Post_Search_Ajax();
 	}
 
 	/**


### PR DESCRIPTION
**Problem**
After updating CMB2, the fields that show the connections to other CTPs on each of the single edit screen are not showing content, nor you can update or change content.

This only happens with the Post Ajax Select Fields

**Solution**
Check why the class isnt being included, and fix that.