### PR TITLE
When deleting/trashing recipes they still stay on the day plan in the back-end - Fix/20

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -246,7 +246,6 @@ class Admin {
 								unset( $new_connections[ $ckey ] );
 							}
 						}
-
 						// Now we save the field.
 						update_post_meta( $con_id, $connected_key, $new_connections, $their_connections );
 					}

--- a/classes/class-integrations.php
+++ b/classes/class-integrations.php
@@ -94,10 +94,8 @@ class Integrations {
 	 * @return void
 	 */
 	public function cmb2_post_search_ajax() {
-		if ( class_exists( 'CMB2_Bootstrap_260' ) ) {
-			require_once LSX_HEALTH_PLAN_PATH . 'vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php';
-			$this->cmb2_post_search_ajax = new \MAG_CMB2_Field_Post_Search_Ajax();
-		}
+		require_once LSX_HEALTH_PLAN_PATH . 'vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php';
+		$this->cmb2_post_search_ajax = new \MAG_CMB2_Field_Post_Search_Ajax();
 	}
 
 	/**

--- a/vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php
+++ b/vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php
@@ -46,6 +46,7 @@ if ( ! class_exists( 'MAG_CMB2_Field_Post_Search_Ajax' ) ) {
 					}
 					foreach ( $value as $val ) {
 						$handle = ( $field->args( 'sortable' ) ) ? '<span class="hndl"></span>' : '';
+						$li_css = '';
 						if ( $field->args( 'object_type' ) == 'user' ) {
 							$guid  = get_edit_user_link( $val );
 							$user  = get_userdata( $val );
@@ -53,8 +54,11 @@ if ( ! class_exists( 'MAG_CMB2_Field_Post_Search_Ajax' ) ) {
 						} else {
 							$guid  = get_edit_post_link( $val );
 							$title = get_the_title( $val );
+							if ( 'trash' === get_post_status( $val ) ) {
+								$li_css = 'display:none;';
+							}
 						}
-						echo '<li>' . $handle . '<input type="hidden" name="' . $field_name . '_results[]" value="' . $val . '"><a href="' . $guid . '" target="_blank" class="edit-link">' . $title . '</a><a class="remover"><span class="dashicons dashicons-no"></span><span class="dashicons dashicons-dismiss"></span></a></li>';
+						echo '<li style="' . $li_css . '">' . $handle . '<input type="hidden" name="' . $field_name . '_results[]" value="' . $val . '"><a href="' . $guid . '" target="_blank" class="edit-link">' . $title . '</a><a class="remover"><span class="dashicons dashicons-no"></span><span class="dashicons dashicons-dismiss"></span></a></li>';
 					}
 				}
 				echo '</ul>';


### PR DESCRIPTION
**Problem**
When you trash a recipe (or any LSX HP post type) that has already been linked to a day it still stays on the day plan which results in an empty recipes tab content on the day.

**Solution**
We have added in a filter to the `delete_post` action,  and we run through the custom fields and delete the id of the current post from all the connected ones.

You can trash a post,  and restore it without breaking the connection.

**Testing - Trashing and Restoring an item**
If you send an item to the trash,  and then restore it.  The post connections should still be there.  They are not deleted until the item it "permanently deleted".

1. Create a [new](https://lsx-health-plan.lsdev.biz/wp-admin/post-new.php?post_type=recipe) dummy recipe
2. Connect that recipe to a day play.
3. Open the [edit](https://lsx-health-plan.lsdev.biz/wp-admin/post.php?post=2557&action=edit&classic-editor) day plan so you can see the connected recipe.
4. Then go to the recipe and move it to the trash.
5. Refresh the [edit plan](https://lsx-health-plan.lsdev.biz/wp-admin/post.php?post=2557&action=edit&classic-editor) page, the recipe should not be showing.
6. Go and restore the recipe from the trash.
7. Now it should be showing again on the [edit plan](https://lsx-health-plan.lsdev.biz/wp-admin/post.php?post=2557&action=edit&classic-editor) page.
