### PR TITLE
Custom Fields Duplicating when saving - Fix/17

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -150,19 +150,25 @@ class Admin {
 	 * Updates the connected posts witht he current post ID
 	 *
 	 * @param [type] $values
-	 * @param [type] $current_ID
+	 * @param [type] $current_id
 	 * @param [type] $connected_key
 	 * @return void
 	 */
-	public function add_connected_posts( $values, $current_ID, $connected_key ) {
+	public function add_connected_posts( $values, $current_id, $connected_key ) {
 		foreach ( $values as $value ) {
-			$current_post_array = get_post_meta( $value, $connected_key, true );
+			$current_post_array = get_post_meta( $value, $connected_key, true );	
 			$previous_values    = $current_post_array;
+
+			if ( ! empty( $current_post_array ) ) {
+				$current_post_array = array_map( 'strval', $current_post_array );
+				array_unique( $current_post_array );
+			}
+			
 			// If the current connected post has no saved connections then we create it.
 			if ( false === $current_post_array || empty( $current_post_array ) ) {
-				$current_post_array = array( $current_ID );
-			} elseif ( ! in_array( $current_ID, $current_post_array, true ) ) {
-				$current_post_array[] = $current_ID;
+				$current_post_array = array( $current_id );
+			} elseif ( ! in_array( (string) $current_id, $current_post_array, true ) ) {
+				$current_post_array[] = $current_id;
 			}
 
 			// Check if the values are empty, if not update them.

--- a/classes/class-integrations.php
+++ b/classes/class-integrations.php
@@ -94,10 +94,8 @@ class Integrations {
 	 * @return void
 	 */
 	public function cmb2_post_search_ajax() {
-		if ( class_exists( 'CMB2_Bootstrap_260' ) ) {
-			require_once LSX_HEALTH_PLAN_PATH . 'vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php';
-			$this->cmb2_post_search_ajax = new \MAG_CMB2_Field_Post_Search_Ajax();
-		}
+		require_once LSX_HEALTH_PLAN_PATH . 'vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php';
+		$this->cmb2_post_search_ajax = new \MAG_CMB2_Field_Post_Search_Ajax();
 	}
 
 	/**

--- a/vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php
+++ b/vendor/lsx-field-post-search-ajax/cmb-field-post-search-ajax.php
@@ -44,6 +44,7 @@ if ( ! class_exists( 'MAG_CMB2_Field_Post_Search_Ajax' ) ) {
 					if ( ! is_array( $value ) ) {
 						$value = array( $value );
 					}
+					$value = array_unique( $value );
 					foreach ( $value as $val ) {
 						$handle = ( $field->args( 'sortable' ) ) ? '<span class="hndl"></span>' : '';
 						if ( $field->args( 'object_type' ) == 'user' ) {


### PR DESCRIPTION
**Problem**
When editing an item like recipes, and connecting it to another day.  All the days that were already connected, had another recipe ID saved against them.   So on the day screen it showed multiple recipes with the same name.

**Solution**
Make sure the array is made "unique" before saving,  this will make sure no values are duplicated.  Also make sure the post meta box "uniques" the array as well.

**Testing**
The testing details are on this [task](https://github.com/lightspeeddevelopment/lsx-health-plan/issues/17).   You just need to edit a recipe, and add it to a new "plan".   Then go view the plan that was already connected.   are there duplicated showing?