### PR TITLE
- Adding in fix for Breadcrumb Translations #70

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 ## Change log
 
+### 1.3.1
+* Fix - Adding in Fix to translate breadcrumbs if endpoints where translated.
+
 ### 1.3.0 - 20 February 2019
 * Dev - Separated the "Snack" boxes from the Meal Plan columns.
 * Dev - Added in an archive description field for the recipes post type archive.

--- a/classes/class-woocommerce.php
+++ b/classes/class-woocommerce.php
@@ -133,6 +133,10 @@ class Woocommerce {
 					1 => false,
 				);
 			}
+			$endpoint_translation = \lsx_health_plan\functions\get_option( 'endpoint_' . $endpoint, false );
+			if ( false !== $endpoint_translation && '' !== $endpoint_translation ) {
+				$endpoint = $endpoint_translation;
+			}
 
 			$crumbs = $new_crumbs;
 		}

--- a/classes/class-woocommerce.php
+++ b/classes/class-woocommerce.php
@@ -135,7 +135,7 @@ class Woocommerce {
 				$new_crumbs[3] = array(
 					0 => ucwords( $endpoint ),
 					1 => false,
-				);			
+				);
 			}
 
 			$crumbs = $new_crumbs;

--- a/classes/class-woocommerce.php
+++ b/classes/class-woocommerce.php
@@ -124,6 +124,10 @@ class Woocommerce {
 					1 => false,
 				);
 			} else {
+				$endpoint_translation = \lsx_health_plan\functions\get_option( 'endpoint_' . $endpoint, false );
+				if ( false !== $endpoint_translation && '' !== $endpoint_translation ) {
+					$endpoint = $endpoint_translation;
+				}	
 				$new_crumbs[2] = array(
 					0 => get_the_title(),
 					1 => get_permalink(),
@@ -131,12 +135,8 @@ class Woocommerce {
 				$new_crumbs[3] = array(
 					0 => ucwords( $endpoint ),
 					1 => false,
-				);
-			}
-			$endpoint_translation = \lsx_health_plan\functions\get_option( 'endpoint_' . $endpoint, false );
-			if ( false !== $endpoint_translation && '' !== $endpoint_translation ) {
-				$endpoint = $endpoint_translation;
-			}
+				);				
+			}				
 
 			$crumbs = $new_crumbs;
 		}

--- a/classes/class-woocommerce.php
+++ b/classes/class-woocommerce.php
@@ -127,7 +127,7 @@ class Woocommerce {
 				$endpoint_translation = \lsx_health_plan\functions\get_option( 'endpoint_' . $endpoint, false );
 				if ( false !== $endpoint_translation && '' !== $endpoint_translation ) {
 					$endpoint = $endpoint_translation;
-				}	
+				}
 				$new_crumbs[2] = array(
 					0 => get_the_title(),
 					1 => get_permalink(),
@@ -135,8 +135,8 @@ class Woocommerce {
 				$new_crumbs[3] = array(
 					0 => ucwords( $endpoint ),
 					1 => false,
-				);				
-			}				
+				);			
+			}
 
 			$crumbs = $new_crumbs;
 		}

--- a/lsx-health-plan.php
+++ b/lsx-health-plan.php
@@ -4,7 +4,7 @@
  * Plugin URI:	https://github.com/lightspeeddevelopment/lsx-health-plan
  * Description:	LSX Health Plan extension adds a meal and workout plan, with recipes.
  * Author:		LightSpeed
- * Version: 	1.3.0
+ * Version: 	1.3.1
  * Author URI: 	https://www.lsdev.biz/
  * License: 	GPL3
  * Text Domain: lsx-health-plan
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'LSX_HEALTH_PLAN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_HEALTH_PLAN_CORE', __FILE__ );
 define( 'LSX_HEALTH_PLAN_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_HEALTH_PLAN_VER', '1.3.0' );
+define( 'LSX_HEALTH_PLAN_VER', '1.3.1' );
 
 /* ======================= Below is the Plugin Class init ========================= */
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Added in a call to translations endpoints to also pull through the endpoint translations into the breadcrumbs.

### Benefits

Changing the Endpoint translations in the LSX Health Plan Settings will now also update the breadcrumbs through the site where needed.

### Possible Drawbacks

None

### Verification Process

Added in the suggested changes and tested locally on a fresh LSX HP Install.

### Checklist:


- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ x] I have added tests to cover my change.
- [x ] All new and existing tests passed.

### Changelog Entry

1.3.1
* Fix - Adding in Fix to translate breadcrumbs if endpoints where translated.
