### PR TITLE
Added in a statement to to check a video exists before outputting a play button

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 # Change log
 
+## [[1.3.2]](https://github.com/lightspeeddevelopment/lsx-health-plan/releases/tag/1.3.2) - Unreleased
+
+### Fixed
+- Added in a statement to to check a video exists before outputting the video play button.
+
 
 ## [[1.3.1]](https://github.com/lightspeeddevelopment/lsx-health-plan/releases/tag/1.3.1) - 2020-03-31
 

--- a/templates/tab-content-workout.php
+++ b/templates/tab-content-workout.php
@@ -156,7 +156,7 @@
 													$this_row[]              = '<td class="muscle-field-item center-mobile">' . esc_html( $group['muscle'] ) . '</td>';
 													$table_headers['muscle'] = true;
 												}
-												if ( isset( $group['connected_videos'] ) && '' !== $group['connected_videos'] ) {
+												if ( isset( $group['connected_videos'] ) && '' !== $group['connected_videos'] && \lsx_health_plan\functions\check_posts_exist( $group['connected_videos'] ) ) {
 													$this_row[]             = '<td class="video-button-item center-mobile">' . lsx_health_plan_workout_video_play_button( $m, $group, false ) . '</td>';
 													$table_headers['video'] = true;
 												}


### PR DESCRIPTION
### Description of the Change
Added in a statement to to check a video exists before outputting a play button

### Benefits
The play button will no longer load empty pop ups.

### Verification Process
Open a workout on the demo site, which has no videos assigned.  The frontend should show no play button.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry
Added in a statement to to check a video exists before outputting the video play button.

