### PR TITLE
Adding in the rest support for the post types, enabling WP Blocks

### DIFF
--- a/classes/class-meal.php
+++ b/classes/class-meal.php
@@ -78,6 +78,7 @@ class Meal {
 			'publicly_queryable' => true,
 			'show_ui'            => true,
 			'show_in_menu'       => true,
+			'show_in_rest'       => true,
 			'menu_icon'          => 'dashicons-carrot',
 			'query_var'          => true,
 			'rewrite'            => false,

--- a/classes/class-plan.php
+++ b/classes/class-plan.php
@@ -76,6 +76,7 @@ class Plan {
 			'publicly_queryable' => true,
 			'show_ui'            => true,
 			'show_in_menu'       => true,
+			'show_in_rest'       => true,
 			'menu_icon'          => 'dashicons-welcome-write-blog',
 			'query_var'          => true,
 			'rewrite'            => array(

--- a/classes/class-recipe.php
+++ b/classes/class-recipe.php
@@ -101,6 +101,7 @@ class Recipe {
 			'publicly_queryable' => true,
 			'show_ui'            => true,
 			'show_in_menu'       => true,
+			'show_in_rest'       => true,
 			'menu_icon'          => 'dashicons-editor-ul',
 			'query_var'          => true,
 			'rewrite'            => array(

--- a/classes/class-tip.php
+++ b/classes/class-tip.php
@@ -75,6 +75,7 @@ class Tip {
 			'publicly_queryable' => false,
 			'show_ui'            => true,
 			'show_in_menu'       => true,
+			'show_in_rest'       => true,
 			'menu_icon'          => 'dashicons-admin-post',
 			'query_var'          => true,
 			'rewrite'            => false,

--- a/classes/class-video.php
+++ b/classes/class-video.php
@@ -75,6 +75,7 @@ class Video {
 			'publicly_queryable' => true,
 			'show_ui'            => true,
 			'show_in_menu'       => true,
+			'show_in_rest'       => true,
 			'menu_icon'          => 'dashicons-format-video',
 			'query_var'          => true,
 			'rewrite'            => false,

--- a/classes/class-workout.php
+++ b/classes/class-workout.php
@@ -76,6 +76,7 @@ class Workout {
 			'publicly_queryable' => true,
 			'show_ui'            => true,
 			'show_in_menu'       => true,
+			'show_in_rest'       => true,
 			'menu_icon'          => 'dashicons-universal-access',
 			'query_var'          => true,
 			'rewrite'            => false,


### PR DESCRIPTION
### Description of the Change
Adding in the `'show_in_rest'       => true,` for the post types to enable the WP block support.

### Benefits
This will allow us to use the WP Blocks to build a plan.

### Possible Drawbacks
This might increase content management until the templates can be properly integrated.

### Verification Process
You should be able to switch to the block editor on any of the LSX HP post types.
