### PR TITLE
Add/exercise post type

### DIFF
--- a/classes/class-endpoints.php
+++ b/classes/class-endpoints.php
@@ -86,5 +86,14 @@ class Endpoints {
 			}
 		}
 		add_rewrite_rule( 'plan/([^/]+)/' . $recipe . '/?$', 'index.php?plan=$matches[1]&endpoint=recipes', 'top' );
+
+		// Exercise.
+		if ( post_type_exists( 'exercise' ) ) {
+			$exercise = \lsx_health_plan\functions\get_option( 'endpoint_exercise', false );
+			if ( false === $exercise ) {
+				$exercise = 'exercises';
+			}
+		}
+		add_rewrite_rule( 'plan/([^/]+)/' . $exercise . '/?$', 'index.php?plan=$matches[1]&endpoint=exercises', 'top' );
 	}
 }

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -83,7 +83,9 @@ class Exercise {
 			'show_in_rest'       => true,
 			'menu_icon'          => 'dashicons-universal-access',
 			'query_var'          => true,
-			'rewrite'            => array( 'slug' => 'exercise' ),
+			'rewrite'            => array(
+				'slug' => 'exercise',
+			),
 			'capability_type'    => 'post',
 			'has_archive'        => 'exercises',
 			'hierarchical'       => false,

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -30,13 +30,14 @@ class Exercise {
 	 * Contructor
 	 */
 	public function __construct() {
-		if ( true !== \lsx_health_plan\functions\get_option( 'exercise_disabled', true ) ) {
+		if ( false !== \lsx_health_plan\functions\get_option( 'exercise_enabled', false ) ) {
 			add_action( 'init', array( $this, 'register_post_type' ) );
-			add_action( 'init', array( $this, 'taxonomy_setup' ) );
+			add_action( 'init', array( $this, 'workout_taxonomy_setup' ) );
+			add_action( 'init', array( $this, 'exercise_type_taxonomy_setup' ) );
+			add_action( 'init', array( $this, 'equipment_taxonomy_setup' ) );
 			add_filter( 'lsx_health_plan_single_template', array( $this, 'enable_post_type' ), 10, 1 );
 			add_filter( 'lsx_health_plan_connections', array( $this, 'enable_connections' ), 10, 1 );
 			add_action( 'cmb2_admin_init', array( $this, 'video_metabox' ) );
-			add_action( 'cmb2_admin_init', array( $this, 'exercise_connections' ), 15 );
 		}
 	}
 
@@ -89,18 +90,19 @@ class Exercise {
 			'menu_position'      => null,
 			'supports'           => array(
 				'title',
+				'thumbnail',
 			),
 		);
 		register_post_type( 'exercise', $args );
 	}
 
 	/**
-	 * Register the Week taxonomy.
+	 * Register the Workout taxonomy.
 	 */
-	public function taxonomy_setup() {
+	public function workout_taxonomy_setup() {
 		$labels = array(
-			'name'              => esc_html_x( 'Week', 'taxonomy general name', 'lsx-health-plan' ),
-			'singular_name'     => esc_html_x( 'Week', 'taxonomy singular name', 'lsx-health-plan' ),
+			'name'              => esc_html_x( 'Workout Type', 'taxonomy general name', 'lsx-health-plan' ),
+			'singular_name'     => esc_html_x( 'Workout', 'taxonomy singular name', 'lsx-health-plan' ),
 			'search_items'      => esc_html__( 'Search', 'lsx-health-plan' ),
 			'all_items'         => esc_html__( 'All', 'lsx-health-plan' ),
 			'parent_item'       => esc_html__( 'Parent', 'lsx-health-plan' ),
@@ -109,7 +111,7 @@ class Exercise {
 			'update_item'       => esc_html__( 'Update', 'lsx-health-plan' ),
 			'add_new_item'      => esc_html__( 'Add New', 'lsx-health-plan' ),
 			'new_item_name'     => esc_html__( 'New Name', 'lsx-health-plan' ),
-			'menu_name'         => esc_html__( 'Weeks', 'lsx-health-plan' ),
+			'menu_name'         => esc_html__( 'Workouts', 'lsx-health-plan' ),
 		);
 
 		$args = array(
@@ -119,11 +121,79 @@ class Exercise {
 			'show_admin_column' => true,
 			'query_var'         => true,
 			'rewrite'           => array(
-				'slug' => 'week',
+				'slug' => 'workout',
 			),
 		);
 
-		register_taxonomy( 'week', array( 'plan' ), $args );
+		register_taxonomy( 'workout', array( 'exercise' ), $args );
+	}
+
+	/**
+	 * Register the Exercise taxonomy.
+	 *
+	 * @return void
+	 */
+	public function exercise_type_taxonomy_setup() {
+		$labels = array(
+			'name'              => esc_html_x( 'Exercise Type', 'taxonomy general name', 'lsx-health-plan' ),
+			'singular_name'     => esc_html_x( 'Exercise Type', 'taxonomy singular name', 'lsx-health-plan' ),
+			'search_items'      => esc_html__( 'Search', 'lsx-health-plan' ),
+			'all_items'         => esc_html__( 'All', 'lsx-health-plan' ),
+			'parent_item'       => esc_html__( 'Parent', 'lsx-health-plan' ),
+			'parent_item_colon' => esc_html__( 'Parent:', 'lsx-health-plan' ),
+			'edit_item'         => esc_html__( 'Edit', 'lsx-health-plan' ),
+			'update_item'       => esc_html__( 'Update', 'lsx-health-plan' ),
+			'add_new_item'      => esc_html__( 'Add New', 'lsx-health-plan' ),
+			'new_item_name'     => esc_html__( 'New Name', 'lsx-health-plan' ),
+			'menu_name'         => esc_html__( 'Exercise Types', 'lsx-health-plan' ),
+		);
+
+		$args = array(
+			'hierarchical'      => true,
+			'labels'            => $labels,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'query_var'         => true,
+			'rewrite'           => array(
+				'slug' => 'exercise-type',
+			),
+		);
+
+		register_taxonomy( 'exercise-type', array( 'exercise' ), $args );
+	}
+
+	/**
+	 * Register the Exercise taxonomy.
+	 *
+	 * @return void
+	 */
+	public function equipment_taxonomy_setup() {
+		$labels = array(
+			'name'              => esc_html_x( 'Equipment', 'taxonomy general name', 'lsx-health-plan' ),
+			'singular_name'     => esc_html_x( 'Equipment', 'taxonomy singular name', 'lsx-health-plan' ),
+			'search_items'      => esc_html__( 'Search', 'lsx-health-plan' ),
+			'all_items'         => esc_html__( 'All', 'lsx-health-plan' ),
+			'parent_item'       => esc_html__( 'Parent', 'lsx-health-plan' ),
+			'parent_item_colon' => esc_html__( 'Parent:', 'lsx-health-plan' ),
+			'edit_item'         => esc_html__( 'Edit', 'lsx-health-plan' ),
+			'update_item'       => esc_html__( 'Update', 'lsx-health-plan' ),
+			'add_new_item'      => esc_html__( 'Add New', 'lsx-health-plan' ),
+			'new_item_name'     => esc_html__( 'New Name', 'lsx-health-plan' ),
+			'menu_name'         => esc_html__( 'Equipment', 'lsx-health-plan' ),
+		);
+
+		$args = array(
+			'hierarchical'      => true,
+			'labels'            => $labels,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'query_var'         => true,
+			'rewrite'           => array(
+				'slug' => 'equipment',
+			),
+		);
+
+		register_taxonomy( 'equipment', array( 'exercise' ), $args );
 	}
 
 	/**
@@ -144,8 +214,11 @@ class Exercise {
 	 * @return void
 	 */
 	public function enable_connections( $connections = array() ) {
-		$connections['exercise']['connected_plans'] = 'connected_exercises';
-		$connections['plan']['connected_exercises'] = 'connected_plans';
+		$connections['exercise']['connected_workouts'] = 'connected_exercises';
+		$connections['workout']['connected_exercise']  = 'connected_workouts';
+
+		$connections['tip']['connected_exercises'] = 'connected_tips';
+		$connections['exercise']['connected_tips'] = 'connected_exercises';
 		return $connections;
 	}
 

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -85,7 +85,7 @@ class Exercise {
 			'query_var'          => true,
 			'rewrite'            => false,
 			'capability_type'    => 'post',
-			'has_archive'        => array( 'slug' => 'exercises' ),
+			'has_archive'        => 'exercises',
 			'hierarchical'       => false,
 			'menu_position'      => null,
 			'supports'           => array(

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -85,7 +85,7 @@ class Exercise {
 			'query_var'          => true,
 			'rewrite'            => false,
 			'capability_type'    => 'post',
-			'has_archive'        => false,
+			'has_archive'        => array( 'slug' => 'exercises' ),
 			'hierarchical'       => false,
 			'menu_position'      => null,
 			'supports'           => array(

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -83,7 +83,7 @@ class Exercise {
 			'show_in_rest'       => true,
 			'menu_icon'          => 'dashicons-universal-access',
 			'query_var'          => true,
-			'rewrite'            => false,
+			'rewrite'            => array( 'slug' => 'exercise' ),
 			'capability_type'    => 'post',
 			'has_archive'        => 'exercises',
 			'hierarchical'       => false,

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -1,0 +1,194 @@
+<?php
+namespace lsx_health_plan\classes;
+
+/**
+ * Contains the exercise post type
+ *
+ * @package lsx-health-plan
+ */
+class Exercise {
+
+	/**
+	 * Holds class instance
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      object \lsx_health_plan\classes\Exercise()
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Holds post_type slug used as an index
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      string
+	 */
+	public $slug = 'exercise';
+
+	/**
+	 * Contructor
+	 */
+	public function __construct() {
+		if ( true !== \lsx_health_plan\functions\get_option( 'exercise_disabled', true ) ) {
+			add_action( 'init', array( $this, 'register_post_type' ) );
+			add_action( 'init', array( $this, 'taxonomy_setup' ) );
+			add_filter( 'lsx_health_plan_single_template', array( $this, 'enable_post_type' ), 10, 1 );
+			add_filter( 'lsx_health_plan_connections', array( $this, 'enable_connections' ), 10, 1 );
+			add_action( 'cmb2_admin_init', array( $this, 'video_metabox' ) );
+			add_action( 'cmb2_admin_init', array( $this, 'exercise_connections' ), 15 );
+		}
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return    object \lsx_health_plan\classes\Exercise()    A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+	/**
+	 * Register the post type.
+	 */
+	public function register_post_type() {
+		$labels = array(
+			'name'               => esc_html__( 'Exercise', 'lsx-health-plan' ),
+			'singular_name'      => esc_html__( 'Exercises', 'lsx-health-plan' ),
+			'add_new'            => esc_html_x( 'Add New', 'post type general name', 'lsx-health-plan' ),
+			'add_new_item'       => esc_html__( 'Add New', 'lsx-health-plan' ),
+			'edit_item'          => esc_html__( 'Edit', 'lsx-health-plan' ),
+			'new_item'           => esc_html__( 'New', 'lsx-health-plan' ),
+			'all_items'          => esc_html__( 'All', 'lsx-health-plan' ),
+			'view_item'          => esc_html__( 'View', 'lsx-health-plan' ),
+			'search_items'       => esc_html__( 'Search', 'lsx-health-plan' ),
+			'not_found'          => esc_html__( 'None found', 'lsx-health-plan' ),
+			'not_found_in_trash' => esc_html__( 'None found in Trash', 'lsx-health-plan' ),
+			'parent_item_colon'  => '',
+			'menu_name'          => esc_html__( 'Exercises', 'lsx-health-plan' ),
+		);
+		$args   = array(
+			'labels'             => $labels,
+			'public'             => true,
+			'publicly_queryable' => true,
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'show_in_rest'       => true,
+			'menu_icon'          => 'dashicons-universal-access',
+			'query_var'          => true,
+			'rewrite'            => false,
+			'capability_type'    => 'post',
+			'has_archive'        => false,
+			'hierarchical'       => false,
+			'menu_position'      => null,
+			'supports'           => array(
+				'title',
+			),
+		);
+		register_post_type( 'exercise', $args );
+	}
+
+	/**
+	 * Register the Week taxonomy.
+	 */
+	public function taxonomy_setup() {
+		$labels = array(
+			'name'              => esc_html_x( 'Week', 'taxonomy general name', 'lsx-health-plan' ),
+			'singular_name'     => esc_html_x( 'Week', 'taxonomy singular name', 'lsx-health-plan' ),
+			'search_items'      => esc_html__( 'Search', 'lsx-health-plan' ),
+			'all_items'         => esc_html__( 'All', 'lsx-health-plan' ),
+			'parent_item'       => esc_html__( 'Parent', 'lsx-health-plan' ),
+			'parent_item_colon' => esc_html__( 'Parent:', 'lsx-health-plan' ),
+			'edit_item'         => esc_html__( 'Edit', 'lsx-health-plan' ),
+			'update_item'       => esc_html__( 'Update', 'lsx-health-plan' ),
+			'add_new_item'      => esc_html__( 'Add New', 'lsx-health-plan' ),
+			'new_item_name'     => esc_html__( 'New Name', 'lsx-health-plan' ),
+			'menu_name'         => esc_html__( 'Weeks', 'lsx-health-plan' ),
+		);
+
+		$args = array(
+			'hierarchical'      => true,
+			'labels'            => $labels,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'query_var'         => true,
+			'rewrite'           => array(
+				'slug' => 'week',
+			),
+		);
+
+		register_taxonomy( 'week', array( 'plan' ), $args );
+	}
+
+	/**
+	 * Adds the post type to the different arrays.
+	 *
+	 * @param array $post_types
+	 * @return array
+	 */
+	public function enable_post_type( $post_types = array() ) {
+		$post_types[] = $this->slug;
+		return $post_types;
+	}
+
+	/**
+	 * Enables the Bi Directional relationships
+	 *
+	 * @param array $connections
+	 * @return void
+	 */
+	public function enable_connections( $connections = array() ) {
+		$connections['exercise']['connected_plans'] = 'connected_exercises';
+		$connections['plan']['connected_exercises'] = 'connected_plans';
+		return $connections;
+	}
+
+	/**
+	 * Define the metabox and field configurations.
+	 */
+	public function video_metabox() {
+		$cmb = new_cmb2_box(
+			array(
+				'id'           => $this->slug . '_details_metabox',
+				'title'        => __( 'Video Details', 'lsx-health-plan' ),
+				'object_types' => array( $this->slug ), // Post type
+				'context'      => 'normal',
+				'priority'     => 'high',
+				'show_names'   => true,
+			)
+		);
+		$cmb->add_field(
+			array(
+				'name'       => __( 'Featured Video', 'lsx-health-plan' ),
+				'desc'       => __( 'Enable the checkbox to feature this video, featured videos display in any page that has the video shortcode: [lsx_health_plan_featured_videos_block]', 'lsx-health-plan' ),
+				'id'         => $this->slug . '_featured_video',
+				'type'       => 'checkbox',
+				'show_on_cb' => 'cmb2_hide_if_no_cats',
+			)
+		);
+		$cmb->add_field(
+			array(
+				'name'       => __( 'Youtube Source', 'lsx-health-plan' ),
+				'desc'       => __( 'Drop in the url for your video from YouTube in this field, i.e: "https://www.youtube.com/watch?v=9xwazD5SyVg"', 'lsx-health-plan' ),
+				'id'         => $this->slug . '_youtube_source',
+				'type'       => 'oembed',
+				'show_on_cb' => 'cmb2_hide_if_no_cats',
+			)
+		);
+		$cmb->add_field(
+			array(
+				'name'       => __( 'Giphy Source', 'lsx-health-plan' ),
+				'desc'       => __( 'Drop in the iFrame embed code from Giphy in this field, i.e: &lt;iframe src="https://giphy.com/embed/3o7527Rn1HxXWqgxuo" width="480" height="270" frameborder="0" class="giphy-embed" allowfullscreen&gt;&lt;/iframe&gt;', 'lsx-health-plan' ),
+				'id'         => $this->slug . '_giphy_source',
+				'type'       => 'textarea_code',
+				'show_on_cb' => 'cmb2_hide_if_no_cats',
+			)
+		);
+	}
+}

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -101,7 +101,7 @@ class Exercise {
 	 */
 	public function workout_taxonomy_setup() {
 		$labels = array(
-			'name'              => esc_html_x( 'Workout Type', 'taxonomy general name', 'lsx-health-plan' ),
+			'name'              => esc_html_x( 'Workout', 'taxonomy general name', 'lsx-health-plan' ),
 			'singular_name'     => esc_html_x( 'Workout', 'taxonomy singular name', 'lsx-health-plan' ),
 			'search_items'      => esc_html__( 'Search', 'lsx-health-plan' ),
 			'all_items'         => esc_html__( 'All', 'lsx-health-plan' ),

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -91,6 +91,7 @@ class Exercise {
 			'supports'           => array(
 				'title',
 				'thumbnail',
+				'editor',
 			),
 		);
 		register_post_type( 'exercise', $args );

--- a/classes/class-exercise.php
+++ b/classes/class-exercise.php
@@ -119,6 +119,7 @@ class Exercise {
 			'labels'            => $labels,
 			'show_ui'           => true,
 			'show_admin_column' => true,
+			'show_in_rest'      => true,
 			'query_var'         => true,
 			'rewrite'           => array(
 				'slug' => 'workout',

--- a/classes/class-post-type.php
+++ b/classes/class-post-type.php
@@ -40,6 +40,11 @@ class Post_Type {
 		add_filter( 'lsx_health_plan_post_types', array( $this, 'enable_post_types' ) );
 		foreach ( $this->post_types as $index => $post_type ) {
 			$is_disabled = \lsx_health_plan\functions\get_option( $post_type . '_disabled', false );
+			// Check if exercises is enabled, if so disable the videos.
+			if ( 'video' === $post_type && false !== \lsx_health_plan\functions\get_option( 'exercise_enabled', false ) ) {
+				$is_disabled = true;
+			}
+
 			if ( true === $is_disabled || 1 === $is_disabled || 'on' === $is_disabled ) {
 				unset( $this->post_types[ $index ] );
 			} else {

--- a/classes/class-post-type.php
+++ b/classes/class-post-type.php
@@ -78,6 +78,7 @@ class Post_Type {
 			'recipe',
 			'tip',
 			'video',
+			'exercise',
 		);
 		$this->post_types = $post_types;
 		return $post_types;

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -407,7 +407,7 @@ class Settings {
 				'type'        => 'checkbox',
 				'value'       => 1,
 				'default'     => 0,
-				'description' => __( 'Enabling the exercise post type will automatically disable the Workout and Video post types.', 'lsx-health-plan' ),
+				'description' => __( 'Enabling the exercise post type will automatically replace the Video post type.', 'lsx-health-plan' ),
 			)
 		);
 	}

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -380,15 +380,29 @@ class Settings {
 			if ( 'plan' === $post_type ) {
 				continue;
 			}
-			$cmb->add_field(
-				array(
-					'name'    => ucwords( $post_type ),
-					'id'      => $post_type . '_disabled',
-					'type'    => 'checkbox',
-					'value'   => 1,
-					'default' => 0,
-				)
-			);
+
+			if ( 'exercise' === $post_type ) {
+				$cmb->add_field(
+					array(
+						'name'        => ucwords( $post_type ),
+						'id'          => $post_type . '_disabled',
+						'type'        => 'checkbox',
+						'value'       => 1,
+						'default'     => 1,
+						'description' => __( 'Enabling the exercise post type will automatically disable the Workout and Video post types.', 'lsx-health-plan' ),
+					)
+				);
+			} else {
+				$cmb->add_field(
+					array(
+						'name'    => ucwords( $post_type ),
+						'id'      => $post_type . '_disabled',
+						'type'    => 'checkbox',
+						'value'   => 1,
+						'default' => 0,
+					)
+				);
+			}
 		}
 	}
 	/**

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -377,33 +377,39 @@ class Settings {
 		);
 
 		foreach ( $post_types as $post_type ) {
-			if ( 'plan' === $post_type ) {
+			if ( 'plan' === $post_type || 'exercise' === $post_type || ( 'video' === $post_type && false !== \lsx_health_plan\functions\get_option( 'exercise_enabled', false ) ) ) {
 				continue;
 			}
 
-			if ( 'exercise' === $post_type ) {
-				$cmb->add_field(
-					array(
-						'name'        => ucwords( $post_type ),
-						'id'          => $post_type . '_disabled',
-						'type'        => 'checkbox',
-						'value'       => 1,
-						'default'     => 1,
-						'description' => __( 'Enabling the exercise post type will automatically disable the Workout and Video post types.', 'lsx-health-plan' ),
-					)
-				);
-			} else {
-				$cmb->add_field(
-					array(
-						'name'    => ucwords( $post_type ),
-						'id'      => $post_type . '_disabled',
-						'type'    => 'checkbox',
-						'value'   => 1,
-						'default' => 0,
-					)
-				);
-			}
+			$cmb->add_field(
+				array(
+					'name'    => ucwords( $post_type ),
+					'id'      => $post_type . '_disabled',
+					'type'    => 'checkbox',
+					'value'   => 1,
+					'default' => 0,
+				)
+			);
 		}
+		$cmb->add_field(
+			array(
+				'id'          => 'post_type_toggles_enable_title',
+				'type'        => 'title',
+				'name'        => __( 'Enable Post Types', 'lsx-health-plan' ),
+				'default'     => __( 'Enable Post Types', 'lsx-health-plan' ),
+				'description' => __( 'Enable new functionailty like the "exercise" post type.', 'lsx-health-plan' ),
+			)
+		);
+		$cmb->add_field(
+			array(
+				'name'        => __( 'Exercises', 'lsx-health-plan' ),
+				'id'          => 'exercise_enabled',
+				'type'        => 'checkbox',
+				'value'       => 1,
+				'default'     => 0,
+				'description' => __( 'Enabling the exercise post type will automatically disable the Workout and Video post types.', 'lsx-health-plan' ),
+			)
+		);
 	}
 	/**
 	 * Registers the Profile Stat Toggle settings

--- a/classes/class-workout.php
+++ b/classes/class-workout.php
@@ -198,19 +198,41 @@ class Workout {
 					'show_on_cb' => 'cmb2_hide_if_no_cats',
 				) );
 
-				$cmb_group->add_group_field( $group_field_id, array(
-					'name'       => __( 'Video related to this workout', 'lsx-health-plan' ),
-					'id'         => 'connected_videos',
-					'type'       => 'post_search_ajax',
-					// Optional :
-					'limit'      => 1, // Limit selection to X items only (default 1)
-					'sortable'   => true,  // Allow selected items to be sortable (default false)
-					'query_args' => array(
-						'post_type'      => array( 'video' ),
-						'post_status'    => array( 'publish' ),
-						'posts_per_page' => -1,
-					),
-				) );
+				if ( false !== \lsx_health_plan\functions\get_option( 'exercise_enabled', false ) ) {
+					$cmb_group->add_group_field(
+						$group_field_id,
+						array(
+							'name'       => __( 'Exercise related to this workout', 'lsx-health-plan' ),
+							'id'         => 'connected_exercises',
+							'type'       => 'post_search_ajax',
+							// Optional :
+							'limit'      => 1, // Limit selection to X items only (default 1)
+							'sortable'   => true,  // Allow selected items to be sortable (default false)
+							'query_args' => array(
+								'post_type'      => array( 'video' ),
+								'post_status'    => array( 'publish' ),
+								'posts_per_page' => -1,
+							),
+						)
+					);
+				} else {
+					$cmb_group->add_group_field(
+						$group_field_id,
+						array(
+							'name'       => __( 'Video related to this workout', 'lsx-health-plan' ),
+							'id'         => 'connected_videos',
+							'type'       => 'post_search_ajax',
+							// Optional :
+							'limit'      => 1, // Limit selection to X items only (default 1)
+							'sortable'   => true,  // Allow selected items to be sortable (default false)
+							'query_args' => array(
+								'post_type'      => array( 'video' ),
+								'post_status'    => array( 'publish' ),
+								'posts_per_page' => -1,
+							),
+						)
+					);
+				}
 				$i++;
 			};
 		}

--- a/templates/tab-content-workout.php
+++ b/templates/tab-content-workout.php
@@ -156,7 +156,7 @@
 													$this_row[]              = '<td class="muscle-field-item center-mobile">' . esc_html( $group['muscle'] ) . '</td>';
 													$table_headers['muscle'] = true;
 												}
-												if ( isset( $group['connected_videos'] ) && '' !== $group['connected_videos'] && ! empty( \lsx_health_plan\functions\check_posts_exist( array( $group['connected_videos'] ) ) ) ) {
+												if ( post_type_exists( 'video' ) && isset( $group['connected_videos'] ) && '' !== $group['connected_videos'] && ! empty( \lsx_health_plan\functions\check_posts_exist( array( $group['connected_videos'] ) ) ) ) {
 													$this_row[]             = '<td class="video-button-item center-mobile">' . lsx_health_plan_workout_video_play_button( $m, $group, false ) . '</td>';
 													$table_headers['video'] = true;
 												}


### PR DESCRIPTION
### Description of the Change
An exercise post type has been added in, you can activate the post type, which disables the videos.  It is a replacement for that.   Exercises have an archive and a single page.

### Benefits
A workout exercise often has multiple steps, we can now handle all of those steps using the WordPress Block editor.

#### Settings
![Screenshot 2020-04-28 at 11 04 16](https://user-images.githubusercontent.com/1805603/80468864-0bf8fa00-8940-11ea-9991-9a0335fa2b07.png)

#### Post Type
![Screenshot 2020-04-28 at 11 04 03](https://user-images.githubusercontent.com/1805603/80468879-15826200-8940-11ea-9f0d-4d675bfc4909.png)


### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.
