### PR TITLE
Fix/warm up tab

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -935,3 +935,16 @@ function lsx_health_plan_workout_tab_content( $index = 1 ) {
 		include $tab_template_path;
 	}
 }
+
+/**
+ * This will detect and include the Workout sets loop.
+ *
+ * @return void
+ */
+function lsx_health_plan_workout_sets() {
+	$template_path = LSX_HEALTH_PLAN_PATH . 'templates/partials/workout-sets.php';
+	$template_path = apply_filters( 'lsx_health_plan_workout_set_template_path', $template_path );
+	if ( '' !== $template_path && ! empty( $template_path ) ) {
+		include $template_path;
+	}
+}

--- a/templates/partials/workout-grid.php
+++ b/templates/partials/workout-grid.php
@@ -26,8 +26,10 @@ if ( ! empty( $groups ) ) {
 									<?php
 									// We call the button to register the modal, but we do not output it.
 									lsx_health_plan_workout_exercise_button( $group['connected_exercises'], $group, false );
-
-									$featured_image = get_the_post_thumbnail( $group['connected_exercises'], 'lsx-thumbnail-square',array( 'class' => 'aligncenter' ) );
+									$thumbnail_args = array(
+										'class' => 'aligncenter',
+									);
+									$featured_image = get_the_post_thumbnail( $group['connected_exercises'], 'lsx-thumbnail-square', $thumbnail_args );
 									if ( ! empty( $featured_image ) && '' !== $featured_image ) {
 										echo wp_kses_post( $featured_image );
 									} else {

--- a/templates/partials/workout-list.php
+++ b/templates/partials/workout-list.php
@@ -27,8 +27,10 @@ if ( ! empty( $groups ) ) {
 										<?php
 										// We call the button to register the modal, but we do not output it.
 										lsx_health_plan_workout_exercise_button( $group['connected_exercises'], $group, false );
-
-										$featured_image = get_the_post_thumbnail( $group['connected_exercises'], 'lsx-thumbnail-square', array( 'class' => 'aligncenter' ) );
+										$thumbnail_args = array(
+											'class' => 'aligncenter',
+										);
+										$featured_image = get_the_post_thumbnail( $group['connected_exercises'], 'lsx-thumbnail-square', $thumbnail_args );
 										if ( ! empty( $featured_image ) && '' !== $featured_image ) {
 											echo wp_kses_post( $featured_image );
 										} else {

--- a/templates/partials/workout-sets.php
+++ b/templates/partials/workout-sets.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Template used to loop through the workout sets and display the workouts.
+ *
+ * @package lsx-health-plan
+ */
+global $group_name;
+?>
+<div class="sets">
+	<?php
+	$connected_workouts = get_post_meta( get_the_ID(), 'connected_workouts', true );
+	if ( empty( $connected_workouts ) ) {
+		$options = \lsx_health_plan\functions\get_option( 'all' );
+		if ( isset( $options['connected_workouts'] ) && '' !== $options['connected_workouts'] && ! empty( $options['connected_workouts'] ) ) {
+			$connected_workouts = $options['connected_workouts'];
+			if ( ! array( $connected_workouts ) ) {
+				$connected_workouts = array( $connected_workouts );
+			}
+		}
+	}
+	$args     = array(
+		'orderby'   => 'date',
+		'order'     => 'DESC',
+		'post_type' => 'workout',
+		'post__in'  => $connected_workouts,
+	);
+	$workouts = new WP_Query( $args );
+
+	if ( $workouts->have_posts() ) {
+		while ( $workouts->have_posts() ) {
+			$workouts->the_post();
+			$i               = 1;
+			$section_counter = 6;
+			while ( $i <= $section_counter ) {
+
+				$workout_section = 'workout_section_' . ( $i ) . '_title';
+				$workout_desc    = 'workout_section_' . ( $i ) . '_description';
+
+				$section_title = get_post_meta( get_the_ID(), $workout_section, true );
+				$description   = get_post_meta( get_the_ID(), $workout_desc, true );
+
+				if ( '' === $section_title ) {
+					$i++;
+					continue;
+				}
+				?>
+				<div class="set-box set content-box">
+					<h3 class="set-title"><?php echo esc_html( $section_title ); ?></h3>
+					<div class="set-content">
+						<p><?php echo wp_kses_post( apply_filters( 'the_content', $description ) ); ?></p>
+					</div>
+					<?php lsx_health_plan_workout_tab_content( $i ); ?>
+				</div>
+				<?php
+				$i++;
+			}
+		}
+		?>
+	<?php } ?>
+	<?php wp_reset_postdata(); ?>
+</div>
+<?php

--- a/templates/partials/workout-sets.php
+++ b/templates/partials/workout-sets.php
@@ -4,17 +4,20 @@
  *
  * @package lsx-health-plan
  */
-global $group_name;
+global $group_name, $connected_workouts;
+var_dump( $connected_workouts );
 ?>
 <div class="sets">
 	<?php
-	$connected_workouts = get_post_meta( get_the_ID(), 'connected_workouts', true );
-	if ( empty( $connected_workouts ) ) {
-		$options = \lsx_health_plan\functions\get_option( 'all' );
-		if ( isset( $options['connected_workouts'] ) && '' !== $options['connected_workouts'] && ! empty( $options['connected_workouts'] ) ) {
-			$connected_workouts = $options['connected_workouts'];
-			if ( ! array( $connected_workouts ) ) {
-				$connected_workouts = array( $connected_workouts );
+	if ( empty( $connected_workouts ) && null === $connected_workouts ) {
+		$connected_workouts = get_post_meta( get_the_ID(), 'connected_workouts', true );
+		if ( empty( $connected_workouts ) ) {
+			$options = \lsx_health_plan\functions\get_option( 'all' );
+			if ( isset( $options['connected_workouts'] ) && '' !== $options['connected_workouts'] && ! empty( $options['connected_workouts'] ) ) {
+				$connected_workouts = $options['connected_workouts'];
+				if ( ! array( $connected_workouts ) ) {
+					$connected_workouts = array( $connected_workouts );
+				}
 			}
 		}
 	}

--- a/templates/partials/workout-sets.php
+++ b/templates/partials/workout-sets.php
@@ -5,7 +5,6 @@
  * @package lsx-health-plan
  */
 global $group_name, $connected_workouts;
-var_dump( $connected_workouts );
 ?>
 <div class="sets">
 	<?php

--- a/templates/tab-content-warm-up.php
+++ b/templates/tab-content-warm-up.php
@@ -4,9 +4,8 @@
  *
  * @package lsx-health-plan
  */
-?>
+global $group_name, $connected_workouts;
 
-<?php
 $warm_up = get_post_meta( get_the_ID(), 'plan_warmup', true );
 if ( false === $warm_up || '' === $warm_up ) {
 	$options = \lsx_health_plan\functions\get_option( 'all' );
@@ -19,10 +18,8 @@ if ( false !== $warm_up && '' !== $warm_up ) {
 	if ( ! is_array( $warm_up ) ) {
 		$warm_up = array( $warm_up );
 	}
-	$warmup_type = 'page';
-	if ( false !== \lsx_health_plan\functions\get_option( 'exercise_enabled', false ) ) {
-		$warmup_type = array( 'page', 'workout' );
-	}
+
+	$warmup_type  = array( 'page', 'workout', 'exercise' );
 	$warmup_query = new WP_Query(
 		array(
 			'post__in'  => $warm_up,
@@ -34,30 +31,31 @@ if ( false !== $warm_up && '' !== $warm_up ) {
 		while ( $warmup_query->have_posts() ) {
 			$warmup_query->the_post();
 			lsx_entry_before();
-			?>
+			if ( 'workout' === get_post_type() ) {
+				$connected_workouts = array( get_the_ID() );
+				lsx_health_plan_workout_sets();
+			} else {
+				?>
+				<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+					<?php lsx_entry_top(); ?>
+					<div class="entry-content">
+						<?php
+							the_content();
+							wp_link_pages( array(
+								'before'      => '<div class="lsx-postnav-wrapper"><div class="lsx-postnav">',
+								'after'       => '</div></div>',
+								'link_before' => '<span>',
+								'link_after'  => '</span>',
+							) );
+						?>
+					</div><!-- .entry-content -->
+					<?php lsx_entry_bottom(); ?>
+				</article><!-- #post-## -->
+				<?php
+			}
 
-			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-				<?php lsx_entry_top(); ?>
-				<div class="entry-content">
-					<?php
-						the_content();
-						wp_link_pages( array(
-							'before'      => '<div class="lsx-postnav-wrapper"><div class="lsx-postnav">',
-							'after'       => '</div></div>',
-							'link_before' => '<span>',
-							'link_after'  => '</span>',
-						) );
-					?>
-				</div><!-- .entry-content -->
-
-				<?php lsx_entry_bottom(); ?>
-
-			</article><!-- #post-## -->
-
-			<?php
 			lsx_entry_after();
 		}
 		wp_reset_postdata();
-		wp_reset_query();
 	}
 }

--- a/templates/tab-content-workout.php
+++ b/templates/tab-content-workout.php
@@ -64,59 +64,9 @@
 			?>
 			<!-- Pre Workout-->
 			<?php lsx_workout_snacks( 'pre' ); ?>
-			<div class="sets">
-				<?php
-				$connected_workouts = get_post_meta( get_the_ID(), 'connected_workouts', true );
-				if ( empty( $connected_workouts ) ) {
-					$options = \lsx_health_plan\functions\get_option( 'all' );
-					if ( isset( $options['connected_workouts'] ) && '' !== $options['connected_workouts'] && ! empty( $options['connected_workouts'] ) ) {
-						$connected_workouts = $options['connected_workouts'];
-						if ( ! array( $connected_workouts ) ) {
-							$connected_workouts = array( $connected_workouts );
-						}
-					}
-				}
-				$args     = array(
-					'orderby'   => 'date',
-					'order'     => 'DESC',
-					'post_type' => 'workout',
-					'post__in'  => $connected_workouts,
-				);
-				$workouts = new WP_Query( $args );
 
-				if ( $workouts->have_posts() ) {
-					while ( $workouts->have_posts() ) {
-						$workouts->the_post();
-						$i               = 1;
-						$section_counter = 6;
-						while ( $i <= $section_counter ) {
+			<?php lsx_health_plan_workout_sets(); ?>
 
-							$workout_section = 'workout_section_' . ( $i ) . '_title';
-							$workout_desc    = 'workout_section_' . ( $i ) . '_description';
-
-							$section_title = get_post_meta( get_the_ID(), $workout_section, true );
-							$description   = get_post_meta( get_the_ID(), $workout_desc, true );
-
-							if ( '' === $section_title ) {
-								$i++;
-								continue;
-							}
-							?>
-							<div class="set-box set content-box">
-								<h3 class="set-title"><?php echo esc_html( $section_title ); ?></h3>
-								<div class="set-content">
-									<p><?php echo wp_kses_post( apply_filters( 'the_content', $description ) ); ?></p>
-								</div>
-								<?php lsx_health_plan_workout_tab_content( $i ); ?>
-							</div>
-							<?php
-							$i++;
-						}
-					}
-					?>
-				<?php } ?>
-				<?php wp_reset_postdata(); ?>
-			</div>
 			<!-- Post Workout-->
 			<?php lsx_workout_snacks( 'post' ); ?>
 		</div>


### PR DESCRIPTION
### Description
With the new addition of the exercise post type, we may want to add a workout as a warm up.   This has been allowed now.   You can select a page, a workout or a singular exercise to show.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry
Allowing Workouts and Exercises to be used as Warmups.
