### PR TITLE
Fix/shortcode item

### DIFF
--- a/classes/class-core.php
+++ b/classes/class-core.php
@@ -106,7 +106,7 @@ class Core {
 	 * @return void
 	 */
 	public function get_post_types() {
-		$post_types = apply_filters( 'lsx_health_plan_post_types', $this->post_types );
+		$post_types = apply_filters( 'lsx_health_plan_post_types', isset( $this->post_types ) );
 		foreach ( $post_types as $index => $post_type ) {
 			$is_disabled = \cmb2_get_option( 'lsx_health_plan_options', $post_type . '_disabled', false );
 			if ( true === $is_disabled || 1 === $is_disabled || 'on' === $is_disabled ) {

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -435,7 +435,7 @@ class Settings {
 	 * @return void
 	 */
 	public function post_type_toggles( $cmb ) {
-		$post_types = apply_filters( 'lsx_health_plan_post_types', $this->post_types );
+		$post_types = apply_filters( 'lsx_health_plan_post_types', isset( $this->post_types ) );
 
 		$cmb->add_field(
 			array(

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -87,8 +87,6 @@ class Setup {
 		if ( post_type_exists( 'tip' ) ) {
 			add_shortcode( 'lsx_health_plan_featured_tips_block', '\lsx_health_plan\shortcodes\feature_tips_box' );
 		}
-		if ( post_type_exists( 'exercise' ) ) {
-			add_shortcode( 'lsx_health_plan_items', '\lsx_health_plan\shortcodes\exercise_box' );
-		}
+		add_shortcode( 'lsx_health_plan_items', '\lsx_health_plan\shortcodes\exercise_box' );
 	}
 }

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -539,14 +539,11 @@ function lsx_health_plan_weekly_downloads( $weekly_downloads = array() ) {
 }
 
 /**
- * Outputs the featured exercise shortcode
+ * Outputs the featured items of any type shortcode (intended for exercises)
  *
  * @return void
  */
 function lsx_health_plan_items( $args = array() ) {
-	if ( ! post_type_exists( 'exercise' ) ) {
-		return;
-	}
 	include LSX_HEALTH_PLAN_PATH . '/templates/featured-exercise.php';
 }
 

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -415,7 +415,7 @@ function lsx_health_plan_week_plan_block( $args = array() ) {
 		'show_downloads' => false,
 	);
 	$args     = wp_parse_args( $args, $defaults );
-	$weeks = get_terms(
+	$weeks    = get_terms(
 		array(
 			'taxonomy' => 'week',
 			'orderby'  => array(


### PR DESCRIPTION
### Description of the Change

This code is for fixing 2 issues:
- Items shortcode needs to be available when exercise is not active too
- PHP issue: Undefined property: lsx_health_plan\classes\Settings::$post_types

### Benefits

More flexibility and no error on the code

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx-health-plan/issues/107
https://github.com/lightspeeddevelopment/lsx-health-plan/issues/75
