### PR TITLE
Add/112 - Workout tab settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,7 @@
 - Added support and styling for a Grid and List views on the workout tab.
 - Added a "side" field for exercises that displays left, right or nothing if left blank.
 - Refactored the post type class locations.
-
+- Added in settings to control the link destination, the content display and the columns of the grid layout.
 ### Fixed
 - Added in a statement to to check a video exists before outputting the video play button.
 

--- a/classes/post-types/class-workout.php
+++ b/classes/post-types/class-workout.php
@@ -336,7 +336,7 @@ class Workout {
 			$cmb->add_field(
 				array(
 					'id'          => 'workout_tab_columns',
-					'type'        => 'text',
+					'type'        => 'select',
 					'name'        => __( 'Workout Tab Columns', 'lsx-health-plan' ),
 					'description' => __( 'If you are displaying a grid, set the amount of columns you want to use.', 'lsx-health-plan' ),
 					'options'     => array(
@@ -346,6 +346,7 @@ class Workout {
 						'3'  => __( '4', 'lsx-health-plan' ),
 						'2'  => __( '6', 'lsx-health-plan' ),
 					),
+					'default' => '4',
 				)
 			);
 			$cmb->add_field(
@@ -359,6 +360,7 @@ class Workout {
 						'excerpt' => __( 'Excerpt', 'lsx-health-plan' ),
 						'full'    => __( 'Full Content', 'lsx-health-plan' ),
 					),
+					'default' => '',
 				)
 			);
 			$cmb->add_field(
@@ -372,6 +374,7 @@ class Workout {
 						'single' => __( 'Single', 'lsx-health-plan' ),
 						'modal'  => __( 'Modal', 'lsx-health-plan' ),
 					),
+					'default' => 'modal',
 				)
 			);
 			do_action( 'lsx_hp_workout_settings_page', $cmb );

--- a/classes/post-types/class-workout.php
+++ b/classes/post-types/class-workout.php
@@ -316,9 +316,10 @@ class Workout {
 					'id'          => 'workout_settings_title',
 					'type'        => 'title',
 					'name'        => __( 'Workout Settings', 'lsx-health-plan' ),
-					'description' => __( 'All of the settings relating to the exercises post type archive.', 'lsx-health-plan' ),
+					'description' => __( 'Choose the layout, content and link settings for your exercises.', 'lsx-health-plan' ),
 				)
 			);
+
 			$cmb->add_field(
 				array(
 					'id'          => 'workout_tab_layout',
@@ -329,6 +330,47 @@ class Workout {
 						'table' => __( 'Table', 'lsx-health-plan' ),
 						'list'  => __( 'List', 'lsx-health-plan' ),
 						'grid'  => __( 'Grid', 'lsx-health-plan' ),
+					),
+				)
+			);
+			$cmb->add_field(
+				array(
+					'id'          => 'workout_tab_columns',
+					'type'        => 'text',
+					'name'        => __( 'Workout Tab Columns', 'lsx-health-plan' ),
+					'description' => __( 'If you are displaying a grid, set the amount of columns you want to use.', 'lsx-health-plan' ),
+					'options'     => array(
+						'12' => __( '1', 'lsx-health-plan' ),
+						'6'  => __( '2', 'lsx-health-plan' ),
+						'4'  => __( '3', 'lsx-health-plan' ),
+						'3'  => __( '4', 'lsx-health-plan' ),
+						'2'  => __( '6', 'lsx-health-plan' ),
+					),
+				)
+			);
+			$cmb->add_field(
+				array(
+					'id'          => 'workout_tab_content',
+					'type'        => 'select',
+					'name'        => __( 'Workout Tab Content', 'lsx-health-plan' ),
+					'description' => __( 'Choose to show the excerpt, full content or nothing.', 'lsx-health-plan' ),
+					'options'     => array(
+						''        => __( 'None', 'lsx-health-plan' ),
+						'excerpt' => __( 'Excerpt', 'lsx-health-plan' ),
+						'full'    => __( 'Full Content', 'lsx-health-plan' ),
+					),
+				)
+			);
+			$cmb->add_field(
+				array(
+					'id'          => 'workout_tab_link',
+					'type'        => 'select',
+					'name'        => __( 'Workout Tab Link', 'lsx-health-plan' ),
+					'description' => __( 'Choose to show the excerpt, full content or nothing.', 'lsx-health-plan' ),
+					'options'     => array(
+						''       => __( 'None', 'lsx-health-plan' ),
+						'single' => __( 'Single', 'lsx-health-plan' ),
+						'modal'  => __( 'Modal', 'lsx-health-plan' ),
 					),
 				)
 			);

--- a/classes/post-types/class-workout.php
+++ b/classes/post-types/class-workout.php
@@ -335,9 +335,23 @@ class Workout {
 			);
 			$cmb->add_field(
 				array(
+					'id'          => 'workout_tab_link',
+					'type'        => 'select',
+					'name'        => __( 'Workout Tab Link', 'lsx-health-plan' ),
+					'description' => __( 'Choose to show the excerpt, full content or nothing.', 'lsx-health-plan' ),
+					'options'     => array(
+						''       => __( 'None', 'lsx-health-plan' ),
+						'single' => __( 'Single', 'lsx-health-plan' ),
+						'modal'  => __( 'Modal', 'lsx-health-plan' ),
+					),
+					'default' => 'modal',
+				)
+			);
+			$cmb->add_field(
+				array(
 					'id'          => 'workout_tab_columns',
 					'type'        => 'select',
-					'name'        => __( 'Workout Tab Columns', 'lsx-health-plan' ),
+					'name'        => __( 'Grid Columns', 'lsx-health-plan' ),
 					'description' => __( 'If you are displaying a grid, set the amount of columns you want to use.', 'lsx-health-plan' ),
 					'options'     => array(
 						'12' => __( '1', 'lsx-health-plan' ),
@@ -353,8 +367,8 @@ class Workout {
 				array(
 					'id'          => 'workout_tab_content',
 					'type'        => 'select',
-					'name'        => __( 'Workout Tab Content', 'lsx-health-plan' ),
-					'description' => __( 'Choose to show the excerpt, full content or nothing.', 'lsx-health-plan' ),
+					'name'        => __( 'Grid Content', 'lsx-health-plan' ),
+					'description' => __( 'Choose to show the excerpt, full content or nothing. For the grid layout only', 'lsx-health-plan' ),
 					'options'     => array(
 						''        => __( 'None', 'lsx-health-plan' ),
 						'excerpt' => __( 'Excerpt', 'lsx-health-plan' ),
@@ -363,20 +377,7 @@ class Workout {
 					'default' => '',
 				)
 			);
-			$cmb->add_field(
-				array(
-					'id'          => 'workout_tab_link',
-					'type'        => 'select',
-					'name'        => __( 'Workout Tab Link', 'lsx-health-plan' ),
-					'description' => __( 'Choose to show the excerpt, full content or nothing.', 'lsx-health-plan' ),
-					'options'     => array(
-						''       => __( 'None', 'lsx-health-plan' ),
-						'single' => __( 'Single', 'lsx-health-plan' ),
-						'modal'  => __( 'Modal', 'lsx-health-plan' ),
-					),
-					'default' => 'modal',
-				)
-			);
+
 			do_action( 'lsx_hp_workout_settings_page', $cmb );
 		}
 	}

--- a/templates/partials/workout-grid.php
+++ b/templates/partials/workout-grid.php
@@ -48,7 +48,6 @@ if ( ! empty( $groups ) ) {
 						<article class="lsx-slot box-shadow">
 							<div class="exercise-feature-img">
 								<?php echo wp_kses_post( $link_html ); ?>
-								<a data-toggle="modal" href="#workout-exercise-modal-<?php echo esc_attr( $group['connected_exercises'] ); ?>">
 									<?php
 									$thumbnail_args = array(
 										'class' => 'aligncenter',
@@ -87,7 +86,7 @@ if ( ! empty( $groups ) ) {
 									<?php
 								}
 								if ( 'full' === $content_setting ) {
-									echo wp_kses_post( get_the_content() );
+									echo wp_kses_post( get_the_content( null, null, $group['connected_exercises'] ) );
 								}
 							}
 							?>

--- a/templates/partials/workout-grid.php
+++ b/templates/partials/workout-grid.php
@@ -6,7 +6,11 @@
  */
 
 global $group_name;
-$groups = get_post_meta( get_the_ID(), $group_name, true );
+$groups          = get_post_meta( get_the_ID(), $group_name, true );
+$link_setting    = \lsx_health_plan\functions\get_option( 'workout_tab_link', 'single' );
+$content_setting = \lsx_health_plan\functions\get_option( 'workout_tab_content', '' );
+$column_setting  = \lsx_health_plan\functions\get_option( 'workout_tab_columns', '4' );
+
 if ( ! empty( $groups ) ) {
 	?>
 	<div class="set-grid">
@@ -18,14 +22,34 @@ if ( ! empty( $groups ) ) {
 					if ( isset( $group['reps'] ) && '' !== $group['reps'] ) {
 						$reps = '<span class="reps">' . esc_html( $group['reps'] ) . '</span>';
 					}
+
+					// Setup our link and content.
+					switch ( $link_setting ) {
+						case 'single':
+							$link_html  = '<a href="' . get_permalink( $group['connected_exercises'] ) . '">';
+							$link_close = '</a>';
+							break;
+
+						case 'modal':
+							$link_html  = '<a data-toggle="modal" href="#workout-exercise-modal-' . $group['connected_exercises'] . '">';
+							$link_close = '</a>';
+							// We call the button to register the modal, but we do not output it.
+							lsx_health_plan_workout_exercise_button( $group['connected_exercises'], $group, false );
+							break;
+
+						case 'none':
+						default:
+							$link_html  = '';
+							$link_close = '';
+							break;
+					}
 					?>
-					<div class="col-xs-12 col-sm-6 col-md-4">
+					<div class="col-xs-12 col-sm-6 col-md-<?php echo esc_attr( $column_setting ); ?>">
 						<article class="lsx-slot box-shadow">
 							<div class="exercise-feature-img">
+								<?php echo wp_kses_post( $link_html ); ?>
 								<a data-toggle="modal" href="#workout-exercise-modal-<?php echo esc_attr( $group['connected_exercises'] ); ?>">
 									<?php
-									// We call the button to register the modal, but we do not output it.
-									lsx_health_plan_workout_exercise_button( $group['connected_exercises'], $group, false );
 									$thumbnail_args = array(
 										'class' => 'aligncenter',
 									);
@@ -38,11 +62,11 @@ if ( ! empty( $groups ) ) {
 										<?php
 									}
 									?>
-								</a>
+								<?php echo wp_kses_post( $link_close ); ?>
 							</div>
 							<div class="title">
 								<h3>
-									<a data-toggle="modal" href="#workout-exercise-modal-<?php echo esc_attr( $group['connected_exercises'] ); ?>">
+								<?php echo wp_kses_post( $link_html ); ?>
 										<?php
 										$exercise_title = lsx_health_plan_exercise_title( '', '', false, $group['connected_exercises'] );
 										if ( '' !== $reps ) {
@@ -52,8 +76,21 @@ if ( ! empty( $groups ) ) {
 										?>
 									</a>
 								</h3>
-								<a data-toggle="modal" data-target="#workout-exercise-modal-<?php echo esc_attr( $group['connected_exercises'] ); ?>" href="<?php echo esc_url( get_permalink( $group['connected_exercises'] ) ); ?>" class="btn  border-btn"><?php esc_html_e( 'How to do it?', 'lsx-health-plan' ); ?></a>
+								<?php echo wp_kses_post( $link_close ); ?>
 							</div>
+							<?php
+							if ( '' !== $content_setting ) {
+								if ( 'excerpt' === $content_setting ) {
+									$excerpt = \lsx_health_plan\functions\hp_excerpt( $group['connected_exercises'] );
+									?>
+										<p class="lsx-exercises-excerpt"><?php echo wp_kses_post( $excerpt ); ?></p>
+									<?php
+								}
+								if ( 'full' === $content_setting ) {
+									echo wp_kses_post( get_the_content() );
+								}
+							}
+							?>
 						</article>
 					</div>
 					<?php

--- a/templates/partials/workout-list.php
+++ b/templates/partials/workout-list.php
@@ -7,6 +7,8 @@
 
 global $group_name;
 $groups = get_post_meta( get_the_ID(), $group_name, true );
+$link_setting    = \lsx_health_plan\functions\get_option( 'workout_tab_link', 'single' );
+$content_setting = \lsx_health_plan\functions\get_option( 'workout_tab_content', '' );
 
 if ( ! empty( $groups ) ) {
 	?>
@@ -19,12 +21,32 @@ if ( ! empty( $groups ) ) {
 					if ( isset( $group['reps'] ) && '' !== $group['reps'] ) {
 						$reps = '<span class="reps">' . esc_html( $group['reps'] ) . '</span>';
 					}
+					// Setup our link and content.
+					switch ( $link_setting ) {
+						case 'single':
+							$link_html  = '<a href="' . get_permalink( $group['connected_exercises'] ) . '">';
+							$link_close = '</a>';
+							break;
+
+						case 'modal':
+							$link_html  = '<a data-toggle="modal" href="#workout-exercise-modal-' . $group['connected_exercises'] . '">';
+							$link_close = '</a>';
+							// We call the button to register the modal, but we do not output it.
+							lsx_health_plan_workout_exercise_button( $group['connected_exercises'], $group, false );
+							break;
+
+						case 'none':
+						default:
+							$link_html  = '';
+							$link_close = '';
+							break;
+					}
 					?>
 					<article class="lsx-slot box-shadow">
 						<div class="row">
 							<div class="col-sm-6 col-md-2">
 								<div class="exercise-feature-img">
-									<a data-toggle="modal" href="#workout-exercise-modal-<?php echo esc_attr( $group['connected_exercises'] ); ?>">
+									<?php echo wp_kses_post( $link_html ); ?>
 										<?php
 										// We call the button to register the modal, but we do not output it.
 										lsx_health_plan_workout_exercise_button( $group['connected_exercises'], $group, false );
@@ -40,13 +62,13 @@ if ( ! empty( $groups ) ) {
 											<?php
 										}
 										?>
-									</a>
+									<?php echo wp_kses_post( $link_close ); ?>
 								</div>
 							</div>
 							<div class="col-sm-6 col-md-10">
 								<div class="title">
 									<h3>
-										<a data-toggle="modal" href="#workout-exercise-modal-<?php echo esc_attr( $group['connected_exercises'] ); ?>">
+									<?php echo wp_kses_post( $link_html ); ?>
 											<?php
 											$exercise_title = lsx_health_plan_exercise_title( '', '', false, $group['connected_exercises'] );
 											if ( '' !== $reps ) {
@@ -54,10 +76,14 @@ if ( ! empty( $groups ) ) {
 											}
 											echo wp_kses_post( $exercise_title );
 											?>
-										</a>
+										<?php echo wp_kses_post( $link_close ); ?>
 									</h3>
 								</div>
-								<a href="<?php echo esc_url( get_permalink( $group['connected_exercises'] ) ); ?>" class="btn  border-btn"><?php esc_html_e( 'How to do it?', 'lsx-health-plan' ); ?></a>
+								<?php if ( '' !== $link_html ) { ?>
+									<?php echo wp_kses_post( str_replace( '<a' ,'<a class="btn border-btn" ', $link_html ) ); ?>
+									<?php esc_html_e( 'How to do it?', 'lsx-health-plan' ); ?>
+									<?php echo wp_kses_post( $link_close ); ?>
+								<?php } ?>
 							</div>
 						</div>
 					</article>


### PR DESCRIPTION
### Description of the Change
The workout tab settings have been extended to include control for the following;
- Grid Columns, based on the Bootstrap Columns
- Link Destination,  modal, single or none.
- Grid Content, none, description, excerpt.

### Alternate Designs
<img width="762" alt="Screenshot 2020-05-20 at 08 31 40" src="https://user-images.githubusercontent.com/1805603/82417111-5cfd9900-9a7b-11ea-8390-5c3842aac5d5.png">

### Benefits
We can choose to have exercises which only display on the workout tabs, as restricted content, and still have an archive of exercises with free content.    

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues
#112 

### Changelog Entry
Added in settings to control the link destination, the content display and the columns of the grid layout.